### PR TITLE
feat(ci): real-host e2e smoke for pi/openclaw/hermes + runtime fixes it exposed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,6 +160,48 @@ jobs:
           fi
           npx tsx tests/e2e/test_pi_llm.ts
 
+  e2e-host:
+    # Real-host smoke: install the plugin into the actual pi / openclaw /
+    # hermes runtime and run one QA turn through the host's own agent loop.
+    # This is a BLOCKING check — the smoke script retries the QA internally.
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository }}
+    strategy:
+      fail-fast: false
+      matrix:
+        host: [pi, openclaw, hermes]
+    timeout-minutes: 25
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Install Node dependencies (also builds repo .venv via postinstall)
+        run: npm install
+
+      - name: Install host CLIs
+        run: |
+          npm i -g @earendil-works/pi-coding-agent
+          npm i -g openclaw
+
+      - name: Real-host smoke QA (${{ matrix.host }})
+        env:
+          SMOKE_LLM_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
+          SMOKE_LLM_BASE_URL: https://api.deepseek.com
+          SMOKE_LLM_MODEL: ${{ vars.DEEPSEEK_MODEL || 'deepseek-v4-flash' }}
+        run: |
+          if [ -z "$SMOKE_LLM_API_KEY" ]; then
+            echo "SMOKE_LLM_API_KEY not configured — failing (this check is blocking by design)"
+            exit 1
+          fi
+          node tests/e2e/host_smoke.mjs ${{ matrix.host }}
+
   build:
     runs-on: ubuntu-latest
     needs: [lint, test, integration]

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -142,6 +142,12 @@ jobs:
       - name: Sync version from tag
         run: bash scripts/sync-version.sh
 
+      - name: Install dependencies
+        run: npm install
+
+      - name: Build compiled plugin entry (dist/index.js)
+        run: npm run build:openclaw
+
       - name: Stage payload into openclaw/
         run: |
           set -euo pipefail

--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,12 @@ coverage.xml
 
 # MCP config (contains API keys)
 .mcp.json
+
+# OpenClaw staged publish payload (see publish.yml "Stage payload into openclaw/")
+openclaw/tools/
+openclaw/skills/
+openclaw/schemas/
+openclaw/templates/
+openclaw/strategies/
+openclaw/scripts/
+openclaw/*.tgz

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 [![Python](https://img.shields.io/badge/python-%3E=3.10-blue?logo=python&logoColor=white)](https://www.python.org/)
 
-A 股 / 港股 / 美股综合分析、多因子选股和策略回测工具集，可作为 [Pi Agent](https://github.com/anthropics/pi-agent) Extension、[Hermes Agent](https://github.com/NousResearch/hermes-agent) Plugin，或 [OpenClaw](https://docs.openclaw.ai/) Plugin 使用。
+A 股 / 港股 / 美股 / 日股 / 韩股 / 台股综合分析、多因子选股和策略回测工具集，可作为 [Pi Agent](https://github.com/anthropics/pi-agent) Extension、[Hermes Agent](https://github.com/NousResearch/hermes-agent) Plugin，或 [OpenClaw](https://docs.openclaw.ai/) Plugin 使用。
 
 底层共享同一套 Python CLI 工具和 SKILL.md 工作流，上层分别适配三个平台的注册机制。
 
@@ -30,7 +30,7 @@ A 股 / 港股 / 美股综合分析、多因子选股和策略回测工具集，
 
 ## 功能概览
 
-- **31 个工具** — 行情数据、技术分析、K 线形态、资金流向、财务指标、新闻舆情、风险筛查、市场状态等
+- **39 个工具** — 行情数据、技术分析、K 线形态、资金流向、财务指标、新闻舆情、风险筛查、市场状态等
 - **20 个 Skills** — 综合分析、全市场选股、策略回测 + 17 个策略方法论（缠论、波浪、龙头、情绪周期等）
 - **策略回测引擎** — YAML DSL 定义策略，参数化条件组合，自动诊断 + LLM 变异优化
 - **多数据源 Failover** — 9 个数据源自动容灾切换（akshare / tushare / efinance / pytdx / baostock / yfinance / finnhub / longbridge / alphavantage）
@@ -92,10 +92,10 @@ pip install -r tools/requirements.txt
 
 | 包 | 用途 |
 |---|------|
-| akshare | A 股数据源（行情、资金流、财务、新闻） |
-| yfinance | 港股 / 美股数据源 |
+| akshare | A 股数据源（行情、资金流、财务、新闻，含 A 股 ETF） |
+| yfinance | 港股 / 美股 / 日股 / 韩股 / 台股数据源 |
 | pandas / numpy | 数据处理和数值计算 |
-| exchange-calendars | 交易日历（A/HK/US） |
+| exchange-calendars | 交易日历（A/HK/US/JP/KR/TW） |
 | newspaper4k | 新闻正文提取 |
 | pypinyin | 股票名称拼音搜索 |
 | pytdx | A 股 TDX 行情（免费兜底源） |
@@ -122,6 +122,7 @@ pip install -r tools/requirements.txt
 | `BRAVE_API_KEY` | Brave 搜索 |
 | `SERPAPI_KEY` | SerpAPI |
 | `BOCHA_API_KEY` | Bocha AI 搜索 |
+| `SEARXNG_BASE_URLS` | SearXNG 自建实例地址（逗号分隔多个，无需 Key，兜底用） |
 
 **社交舆情（可选）：**
 
@@ -315,10 +316,15 @@ position:
 | 代码格式 | 示例 | 市场 | 数据源 Failover 链 |
 |----------|------|------|---------------------|
 | 6 位纯数字 | `600519`, `000001`, `300750` | A 股 | akshare → tushare → efinance → pytdx → baostock |
+| 6 位纯数字（51/52/56/58/15/16/18 开头） | `510300`, `159915` | A 股 ETF | akshare（基金接口）→ tushare → efinance → pytdx → baostock |
 | `.HK` 结尾 | `00700.HK`, `09988.HK` | 港股 | yfinance → finnhub → longbridge |
 | 英文字母 | `AAPL`, `GOOGL`, `TSLA` | 美股 | yfinance → finnhub → longbridge → alphavantage |
+| `.T` 结尾 | `7203.T` | 日股 | yfinance |
+| `.KS` / `.KQ` 结尾 | `005930.KS`, `035720.KQ` | 韩股 | yfinance |
+| `.TW` / `.TWO` 结尾 | `2330.TW`, `6510.TWO` | 台股 | yfinance |
 
 > 各数据源按优先级自动尝试，前一个失败后自动切换到下一个。未配置相关 env var 的数据源会被跳过。
+> 日/韩/台股仅 yfinance 一个数据源（免费数据延迟约 15 分钟）；港股 / 美股 / 日股 / 韩股 / 台股的 ETF 与其所在市场股票走相同链路。
 
 ## 独立 CLI 使用
 

--- a/docs/hermes-integration.en.md
+++ b/docs/hermes-integration.en.md
@@ -93,8 +93,10 @@ Hermes discovers this plugin through two mechanisms:
 
 ```toml
 [project.entry-points."hermes_agent.plugins"]
-stock-analysis = "hermes:register"
+stock-analysis = "hermes"
 ```
+
+> Note: the entry point must reference the **module** (`hermes`), not `hermes:register` — Hermes 0.19's loader calls `ep.load()` and then `getattr(module, "register")`. Pointing at the function makes `ep.load()` return the function itself, and the loader reports "no register() function" and silently skips tool registration.
 
 2. **Directory discovery**: `hermes/plugin.yaml` serves as the plugin manifest for Hermes CLI installs.
 

--- a/docs/hermes-integration.md
+++ b/docs/hermes-integration.md
@@ -93,8 +93,10 @@ Hermes 通过两种方式发现本插件：
 
 ```toml
 [project.entry-points."hermes_agent.plugins"]
-stock-analysis = "hermes:register"
+stock-analysis = "hermes"
 ```
+
+> 注意：entry point 必须指向**模块**（`hermes`），不能写成 `hermes:register`——Hermes 0.19 的加载器对 entry point 做 `ep.load()` 后直接 `getattr(module, "register")`；若指向函数，`ep.load()` 返回函数本身，加载器会报 "no register() function" 并静默跳过工具注册。
 
 2. **目录发现**：`hermes/plugin.yaml` 作为插件清单，Hermes CLI 安装时使用。
 

--- a/docs/pi-integration.en.md
+++ b/docs/pi-integration.en.md
@@ -102,16 +102,16 @@ export default (pi: ExtensionAPI) => {
       properties: { /* ... */ },
       required: ["symbol"],
     },
-    async execute({ symbol, period = "daily", count = 60 }) {
-      const result = await pi.exec(`${python} ${toolsDir}/stock_data.py kline ${symbol} --period ${period} --count ${count}`);
-      return result.stdout;
+    async execute(_toolCallId, { symbol, period = "daily", count = 60 }) {
+      const result = await pi.exec(python, [`${toolsDir}/stock_data.py`, "kline", symbol, "--period", period, "--count", String(count)]);
+      return { content: [{ type: "text", text: result.stdout }], details: {} };
     },
   });
-  // ... 30 more tools
+  // ... 38 more tools
 };
 ```
 
-Each tool's `execute` method calls the corresponding Python CLI script via `pi.exec()`, passing arguments on the command line and returning JSON from stdout.
+Each tool's `execute` method calls the corresponding Python CLI script via `pi.exec(python, argv)` (argv array form, no shell) and returns Pi 0.83's `AgentToolResult` shape: `{ content: [{ type: "text", text }], details: {} }` with the JSON payload in `content`.
 
 ### Skill Registration
 

--- a/docs/pi-integration.md
+++ b/docs/pi-integration.md
@@ -102,16 +102,16 @@ export default (pi: ExtensionAPI) => {
       properties: { /* ... */ },
       required: ["symbol"],
     },
-    async execute({ symbol, period = "daily", count = 60 }) {
-      const result = await pi.exec(`${python} ${toolsDir}/stock_data.py kline ${symbol} --period ${period} --count ${count}`);
-      return result.stdout;
+    async execute(_toolCallId, { symbol, period = "daily", count = 60 }) {
+      const result = await pi.exec(python, [`${toolsDir}/stock_data.py`, "kline", symbol, "--period", period, "--count", String(count)]);
+      return { content: [{ type: "text", text: result.stdout }], details: {} };
     },
   });
-  // ... 其余 30 个工具
+  // ... 其余 38 个工具
 };
 ```
 
-每个工具的 `execute` 方法通过 `pi.exec()` 调用对应的 Python CLI 脚本，参数通过命令行传递，返回 JSON 格式的标准输出。
+每个工具的 `execute` 方法通过 `pi.exec(python, argv)`（argv 数组形式，不经 shell）调用对应的 Python CLI 脚本，并按 Pi 0.83 的 `AgentToolResult` 契约返回 `{ content: [{ type: "text", text }], details: {} }`（JSON 文本放在 content 里）。
 
 ### Skill 注册
 

--- a/hermes/plugin.yaml
+++ b/hermes/plugin.yaml
@@ -1,6 +1,6 @@
 name: stock-analysis
 version: 0.1.0
-description: "Stock analysis, screening, and strategy backtesting across A/HK/US markets"
+description: "Stock analysis, screening, and strategy backtesting across A/HK/US/JP/KR/TW markets"
 provides_tools:
   - get_kline
   - get_quote

--- a/hermes/schemas.py
+++ b/hermes/schemas.py
@@ -1,13 +1,13 @@
 TOOL_SCHEMAS = [
     {
         "name": "get_kline",
-        "description": "获取股票K线数据（OHLCV）。支持A股（如600519）、港股（如00700.HK）、美股（如AAPL）",
+        "description": "获取股票K线数据（OHLCV）。支持A股（如600519）、港股（如00700.HK）、美股（如AAPL）、日股（如7203.T）、韩股（如005930.KS）、台股（如2330.TW）及A股ETF",
         "parameters": {
             "type": "object",
             "properties": {
                 "symbol": {
                     "type": "string",
-                    "description": "股票代码，如 600519（A股）、00700.HK（港股）、AAPL（美股）",
+                    "description": "股票代码，如 600519（A股）、00700.HK（港股）、AAPL（美股）、7203.T（日股）、005930.KS（韩股）、2330.TW（台股）",
                 },
                 "period": {
                     "type": "string",
@@ -24,7 +24,7 @@ TOOL_SCHEMAS = [
     },
     {
         "name": "get_quote",
-        "description": "获取股票实时行情报价。支持A股、港股、美股",
+        "description": "获取股票实时行情报价。支持A股、港股、美股、日股、韩股、台股",
         "parameters": {
             "type": "object",
             "properties": {
@@ -134,13 +134,13 @@ TOOL_SCHEMAS = [
     },
     {
         "name": "get_market_indices",
-        "description": "获取主要市场指数行情。CN: 上证/深证/创业板/科创50/沪深300；HK: 恒生/国企/科技；US: 道琼斯/纳斯达克/标普500",
+        "description": "获取主要市场指数行情。CN: 上证/深证/创业板/科创50/沪深300；HK: 恒生/国企/科技；US: 道琼斯/纳斯达克/标普500；JP: 日经225/东证；KR: KOSPI/KOSDAQ；TW: 台湾加权",
         "parameters": {
             "type": "object",
             "properties": {
                 "region": {
                     "type": "string",
-                    "enum": ["cn", "hk", "us"],
+                    "enum": ["cn", "hk", "us", "jp", "kr", "tw"],
                     "description": "市场区域，默认 cn",
                 },
             },
@@ -166,7 +166,7 @@ TOOL_SCHEMAS = [
     },
     {
         "name": "get_stock_info",
-        "description": "获取股票基本信息（行业、板块、上市日期、总股本等）。A股返回板块/行业，HK/US返回行业/公司简介",
+        "description": "获取股票基本信息（行业、板块、上市日期、总股本等）。A股返回板块/行业，其他市场返回行业/公司简介",
         "parameters": {
             "type": "object",
             "properties": {
@@ -329,13 +329,13 @@ TOOL_SCHEMAS = [
     },
     {
         "name": "check_trading_day",
-        "description": "查询某日是否为交易日。支持CN（A股）、HK（港股）、US（美股）三市场",
+        "description": "查询某日是否为交易日。支持CN（A股）、HK（港股）、US（美股）、JP（日股）、KR（韩股）、TW（台股）",
         "parameters": {
             "type": "object",
             "properties": {
                 "market": {
                     "type": "string",
-                    "enum": ["CN", "HK", "US"],
+                    "enum": ["CN", "HK", "US", "JP", "KR", "TW"],
                     "description": "市场",
                 },
                 "date": {
@@ -348,13 +348,13 @@ TOOL_SCHEMAS = [
     },
     {
         "name": "get_trading_days",
-        "description": "获取最近/未来N个交易日列表。支持CN/HK/US三市场",
+        "description": "获取最近/未来N个交易日列表。支持CN/HK/US/JP/KR/TW",
         "parameters": {
             "type": "object",
             "properties": {
                 "market": {
                     "type": "string",
-                    "enum": ["CN", "HK", "US"],
+                    "enum": ["CN", "HK", "US", "JP", "KR", "TW"],
                     "description": "市场",
                 },
                 "direction": {
@@ -578,7 +578,7 @@ TOOL_SCHEMAS = [
             "properties": {
                 "market": {
                     "type": "string",
-                    "enum": ["A", "HK", "US", "all"],
+                    "enum": ["A", "HK", "US", "JP", "KR", "TW", "all"],
                     "description": "市场，默认 all",
                 },
             },
@@ -590,7 +590,7 @@ TOOL_SCHEMAS = [
         "parameters": {
             "type": "object",
             "properties": {
-                "market": {"type": "string", "enum": ["A", "HK", "US"], "description": "市场代码"},
+                "market": {"type": "string", "enum": ["A", "HK", "US", "JP", "KR", "TW"], "description": "市场代码"},
                 "symbol": {"type": "string", "description": "股票代码（自动识别市场，与 market 二选一）"},
             },
         },
@@ -671,7 +671,7 @@ TOOL_SCHEMAS = [
     },
     {
         "name": "parse_stock_list",
-        "description": "自选股/文本导入解析 — 从自然语言、CSV、Markdown 表格提取股票，自动识别 A 股 6 位代码、港股 xxxxx.HK、美股 ticker，并调用 name_resolver 处理中文股票名",
+        "description": "自选股/文本导入解析 — 从自然语言、CSV、Markdown 表格提取股票，自动识别 A 股 6 位代码、港股 xxxxx.HK、美股 ticker、日股 xxxx.T、韩股 xxxxxx.KS/KQ、台股 xxxx.TW，并调用 name_resolver 处理中文股票名",
         "parameters": {
             "type": "object",
             "properties": {

--- a/openclaw/.npmignore
+++ b/openclaw/.npmignore
@@ -1,0 +1,4 @@
+node_modules/
+*.tgz
+.venv/
+__pycache__/

--- a/openclaw/README.md
+++ b/openclaw/README.md
@@ -1,6 +1,6 @@
 # Stock Analysis — OpenClaw Plugin
 
-A股 / 港股 / 美股 行情、技术分析、筛选与回测。OpenClaw Gateway 加载后即可在对话中调用 31 个工具。
+A股 / 港股 / 美股 / 日股 / 韩股 / 台股 行情、技术分析、筛选与回测。OpenClaw Gateway 加载后即可在对话中调用 39 个工具。
 
 ## 安装
 
@@ -24,7 +24,7 @@ npm install
 ## 工具列表
 
 ### 行情数据
-- `get_kline` — K线 OHLCV（A/HK/US）
+- `get_kline` — K线 OHLCV（A/HK/US/JP/KR/TW）
 - `get_quote` — 实时报价
 - `get_capital_flow` — A股资金流（个股 / 多日 / 板块）
 - `get_news` — 财经新闻
@@ -37,7 +37,7 @@ npm install
 - `get_volume_analysis` — 量价分析
 
 ### 市场全景
-- `get_market_indices` — 主要指数（CN/HK/US）
+- `get_market_indices` — 主要指数（CN/HK/US/JP/KR/TW）
 - `get_sector_rankings` — A股板块涨跌幅排行
 - `get_market_stats` — A股大盘统计
 - `get_stock_info` — 股票基本信息

--- a/openclaw/index.ts
+++ b/openclaw/index.ts
@@ -45,17 +45,17 @@ export default definePluginEntry({
   id: "stock-analysis",
   name: "Stock Analysis",
   description:
-    "Stock analysis, screening, and strategy backtesting across A/HK/US markets",
+    "Stock analysis, screening, and strategy backtesting across A/HK/US/JP/KR/TW markets",
   register(api) {
     // --- Data Tools ---
 
     api.registerTool({
       name: "get_kline",
       description:
-        "获取股票K线数据（OHLCV）。支持A股（如600519）、港股（如00700.HK）、美股（如AAPL）",
+        "获取股票K线数据（OHLCV）。支持A股（如600519）、港股（如00700.HK）、美股（如AAPL）、日股（如7203.T）、韩股（如005930.KS）、台股（如2330.TW）及A股ETF",
       parameters: Type.Object({
         symbol: Type.String({
-          description: "股票代码，如 600519（A股）、00700.HK（港股）、AAPL（美股）",
+          description: "股票代码，如 600519（A股）、00700.HK（港股）、AAPL（美股）、7203.T（日股）、005930.KS（韩股）、2330.TW（台股）",
         }),
         period: Type.Optional(
           Type.Union(
@@ -80,7 +80,7 @@ export default definePluginEntry({
 
     api.registerTool({
       name: "get_quote",
-      description: "获取股票实时行情报价。支持A股、港股、美股",
+      description: "获取股票实时行情报价。支持A股、港股、美股、日股、韩股、台股",
       parameters: Type.Object({
         symbol: Type.String({ description: "股票代码" }),
       }),
@@ -215,11 +215,11 @@ export default definePluginEntry({
     api.registerTool({
       name: "get_market_indices",
       description:
-        "获取主要市场指数行情。CN: 上证/深证/创业板/科创50/沪深300；HK: 恒生/国企/科技；US: 道琼斯/纳斯达克/标普500",
+        "获取主要市场指数行情。CN: 上证/深证/创业板/科创50/沪深300；HK: 恒生/国企/科技；US: 道琼斯/纳斯达克/标普500；JP: 日经225/东证；KR: KOSPI/KOSDAQ；TW: 台湾加权",
       parameters: Type.Object({
         region: Type.Optional(
           Type.Union(
-            [Type.Literal("cn"), Type.Literal("hk"), Type.Literal("us")],
+            [Type.Literal("cn"), Type.Literal("hk"), Type.Literal("us"), Type.Literal("jp"), Type.Literal("kr"), Type.Literal("tw")],
             { description: "市场区域，默认 cn" }
           )
         ),
@@ -264,7 +264,7 @@ export default definePluginEntry({
     api.registerTool({
       name: "get_stock_info",
       description:
-        "获取股票基本信息（行业、板块、上市日期、总股本等）。A股返回板块/行业，HK/US返回行业/公司简介",
+        "获取股票基本信息（行业、板块、上市日期、总股本等）。A股返回板块/行业，其他市场返回行业/公司简介",
       parameters: Type.Object({
         symbol: Type.String({ description: "股票代码" }),
       }),
@@ -457,10 +457,10 @@ export default definePluginEntry({
     api.registerTool({
       name: "check_trading_day",
       description:
-        "查询某日是否为交易日。支持CN（A股）、HK（港股）、US（美股）三市场",
+        "查询某日是否为交易日。支持CN（A股）、HK（港股）、US（美股）、JP（日股）、KR（韩股）、TW（台股）",
       parameters: Type.Object({
         market: Type.Union(
-          [Type.Literal("CN"), Type.Literal("HK"), Type.Literal("US")],
+          [Type.Literal("CN"), Type.Literal("HK"), Type.Literal("US"), Type.Literal("JP"), Type.Literal("KR"), Type.Literal("TW")],
           { description: "市场" }
         ),
         date: Type.Optional(
@@ -477,10 +477,10 @@ export default definePluginEntry({
 
     api.registerTool({
       name: "get_trading_days",
-      description: "获取最近/未来N个交易日列表。支持CN/HK/US三市场",
+      description: "获取最近/未来N个交易日列表。支持CN/HK/US/JP/KR/TW",
       parameters: Type.Object({
         market: Type.Union(
-          [Type.Literal("CN"), Type.Literal("HK"), Type.Literal("US")],
+          [Type.Literal("CN"), Type.Literal("HK"), Type.Literal("US"), Type.Literal("JP"), Type.Literal("KR"), Type.Literal("TW")],
           { description: "市场" }
         ),
         direction: Type.Optional(
@@ -771,6 +771,9 @@ export default definePluginEntry({
               Type.Literal("A"),
               Type.Literal("HK"),
               Type.Literal("US"),
+              Type.Literal("JP"),
+              Type.Literal("KR"),
+              Type.Literal("TW"),
               Type.Literal("all"),
             ],
             { description: "市场，默认 all" }
@@ -794,7 +797,7 @@ export default definePluginEntry({
       parameters: Type.Object({
         market: Type.Optional(
           Type.Union(
-            [Type.Literal("A"), Type.Literal("HK"), Type.Literal("US")],
+            [Type.Literal("A"), Type.Literal("HK"), Type.Literal("US"), Type.Literal("JP"), Type.Literal("KR"), Type.Literal("TW")],
             { description: "市场代码" }
           )
         ),
@@ -944,7 +947,7 @@ export default definePluginEntry({
     api.registerTool({
       name: "parse_stock_list",
       description:
-        "自选股/文本导入解析 — 从自然语言、CSV、Markdown 表格提取股票，自动识别 A 股 6 位代码、港股 xxxxx.HK、美股 ticker，并调用 name_resolver 处理中文股票名",
+        "自选股/文本导入解析 — 从自然语言、CSV、Markdown 表格提取股票，自动识别 A 股 6 位代码、港股 xxxxx.HK、美股 ticker、日股 xxxx.T、韩股 xxxxxx.KS/KQ、台股 xxxx.TW，并调用 name_resolver 处理中文股票名",
       parameters: Type.Object({
         text: Type.String({ description: "待解析的文本" }),
       }),

--- a/openclaw/index.ts
+++ b/openclaw/index.ts
@@ -28,9 +28,14 @@ const toolsDir = existsSync(join(here, "tools"))
 const repoRoot = dirname(toolsDir);
 const isWin = process.platform === "win32";
 const venvPython = join(repoRoot, ".venv", isWin ? "Scripts" : "bin", "python3");
+// Staged-payload layout (openclaw/tools present in a dev checkout): the venv
+// still lives at the repo root one level up.
+const parentVenvPython = join(repoRoot, "..", ".venv", isWin ? "Scripts" : "bin", "python3");
 
 function pythonBin(): string {
-  return existsSync(venvPython) ? venvPython : "python3";
+  if (existsSync(venvPython)) return venvPython;
+  if (existsSync(parentVenvPython)) return parentVenvPython;
+  return "python3";
 }
 
 async function runPy(script: string, args: string[]): Promise<string> {

--- a/openclaw/openclaw.plugin.json
+++ b/openclaw/openclaw.plugin.json
@@ -1,7 +1,7 @@
 {
   "id": "stock-analysis",
   "name": "Stock Analysis",
-  "description": "Stock analysis, screening, and strategy backtesting across A/HK/US markets (akshare/yfinance/tushare)",
+  "description": "Stock analysis, screening, and strategy backtesting across A/HK/US/JP/KR/TW markets (akshare/yfinance/tushare)",
   "contracts": {
     "tools": [
       "get_kline",

--- a/openclaw/package.json
+++ b/openclaw/package.json
@@ -20,6 +20,7 @@
   },
   "files": [
     "index.ts",
+    "dist/",
     "openclaw.plugin.json",
     "README.md",
     "tools/",

--- a/openclaw/package.json
+++ b/openclaw/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@weaxs/openclaw-stock-analysis",
   "version": "0.1.3",
-  "description": "OpenClaw plugin for stock analysis, screening, and strategy backtesting across A/HK/US markets",
+  "description": "OpenClaw plugin for stock analysis, screening, and strategy backtesting across A/HK/US/JP/KR/TW markets",
   "type": "module",
   "main": "./index.ts",
   "openclaw": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "jiti": "^2.7.0",
         "openai": "^4.104.0",
         "tsx": "^4.22.1",
+        "typebox": "^1.3.10",
         "typescript": "^5.5.0"
       }
     },
@@ -998,6 +999,13 @@
       "optionalDependencies": {
         "fsevents": "~2.3.3"
       }
+    },
+    "node_modules/typebox": {
+      "version": "1.3.10",
+      "resolved": "https://registry.npmjs.org/typebox/-/typebox-1.3.10.tgz",
+      "integrity": "sha512-L0MT00X96q0P30f1NrGULgaSbmu8hfTjWbLULeVoM+j5u0jR5wyefoDquX2NmRa39f0KiNIBo1wWSaVvHJTZlA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/typescript": {
       "version": "5.9.3",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
     "scripts/"
   ],
   "scripts": {
-    "postinstall": "node scripts/setup-python.mjs"
+    "postinstall": "node scripts/setup-python.mjs",
+    "build:openclaw": "esbuild openclaw/index.ts --bundle --format=esm --platform=node --external:openclaw/* --outfile=openclaw/dist/index.js"
   },
   "keywords": [
     "pi-agent",
@@ -76,6 +77,7 @@
     "jiti": "^2.7.0",
     "openai": "^4.104.0",
     "tsx": "^4.22.1",
+    "typebox": "^1.3.10",
     "typescript": "^5.5.0"
   }
 }

--- a/pi/index.ts
+++ b/pi/index.ts
@@ -6,8 +6,12 @@ export default (pi: ExtensionAPI) => {
   const isWin = process.platform === "win32";
   const venvPython = `${__dirname}/../.venv/${isWin ? "Scripts" : "bin"}/python3`;
   const python = existsSync(venvPython) ? venvPython : "python3";
-  const py = (script: string, args: string) =>
-    pi.exec(`${python} ${toolsDir}/${script} ${args}`);
+  const py = (script: string, args: string[]) =>
+    pi.exec(python, [`${toolsDir}/${script}`, ...args]);
+  const asText = (text: string) => ({
+    content: [{ type: "text" as const, text }],
+    details: {},
+  });
 
   // --- Data Tools ---
 
@@ -34,12 +38,16 @@ export default (pi: ExtensionAPI) => {
       },
       required: ["symbol"],
     },
-    async execute({ symbol, period = "daily", count = 60 }) {
-      const result = await py(
-        "stock_data.py",
-        `kline ${symbol} --period ${period} --count ${count}`
-      );
-      return result.stdout;
+    async execute(_id, { symbol, period = "daily", count = 60 }) {
+      const result = await py("stock_data.py", [
+        "kline",
+        symbol,
+        "--period",
+        period,
+        "--count",
+        String(count),
+      ]);
+      return asText(result.stdout);
     },
   });
 
@@ -57,9 +65,9 @@ export default (pi: ExtensionAPI) => {
       },
       required: ["symbol"],
     },
-    async execute({ symbol }) {
-      const result = await py("stock_data.py", `quote ${symbol}`);
-      return result.stdout;
+    async execute(_id, { symbol }) {
+      const result = await py("stock_data.py", ["quote", symbol]);
+      return asText(result.stdout);
     },
   });
 
@@ -81,10 +89,14 @@ export default (pi: ExtensionAPI) => {
         },
       },
     },
-    async execute({ symbol = "", mode = "detail" }) {
-      const symArg = symbol ? ` ${symbol}` : "";
-      const result = await py("stock_data.py", `capital_flow${symArg} --mode ${mode}`);
-      return result.stdout;
+    async execute(_id, { symbol = "", mode = "detail" }) {
+      const result = await py("stock_data.py", [
+        "capital_flow",
+        ...(symbol ? [symbol] : []),
+        "--mode",
+        mode,
+      ]);
+      return asText(result.stdout);
     },
   });
 
@@ -105,9 +117,9 @@ export default (pi: ExtensionAPI) => {
       },
       required: ["symbol"],
     },
-    async execute({ symbol, days = 3 }) {
-      const result = await py("stock_data.py", `news ${symbol} --days ${days}`);
-      return result.stdout;
+    async execute(_id, { symbol, days = 3 }) {
+      const result = await py("stock_data.py", ["news", symbol, "--days", String(days)]);
+      return asText(result.stdout);
     },
   });
 
@@ -125,9 +137,9 @@ export default (pi: ExtensionAPI) => {
       },
       required: ["symbol"],
     },
-    async execute({ symbol }) {
-      const result = await py("stock_data.py", `financials ${symbol}`);
-      return result.stdout;
+    async execute(_id, { symbol }) {
+      const result = await py("stock_data.py", ["financials", symbol]);
+      return asText(result.stdout);
     },
   });
 
@@ -156,12 +168,16 @@ export default (pi: ExtensionAPI) => {
       },
       required: ["symbol"],
     },
-    async execute({ symbol, period = "daily", count = 120 }) {
-      const result = await py(
-        "technical.py",
-        `analyze ${symbol} --period ${period} --count ${count}`
-      );
-      return result.stdout;
+    async execute(_id, { symbol, period = "daily", count = 120 }) {
+      const result = await py("technical.py", [
+        "analyze",
+        symbol,
+        "--period",
+        period,
+        "--count",
+        String(count),
+      ]);
+      return asText(result.stdout);
     },
   });
 
@@ -188,12 +204,16 @@ export default (pi: ExtensionAPI) => {
       },
       required: ["symbol"],
     },
-    async execute({ symbol, period = "daily", days = 60 }) {
-      const result = await py(
-        "pattern.py",
-        `analyze ${symbol} --period ${period} --days ${days}`
-      );
-      return result.stdout;
+    async execute(_id, { symbol, period = "daily", days = 60 }) {
+      const result = await py("pattern.py", [
+        "analyze",
+        symbol,
+        "--period",
+        period,
+        "--days",
+        String(days),
+      ]);
+      return asText(result.stdout);
     },
   });
 
@@ -213,12 +233,13 @@ export default (pi: ExtensionAPI) => {
         },
       },
     },
-    async execute({ region = "cn" }) {
-      const result = await py(
-        "stock_data.py",
-        `market_indices --region ${region}`
-      );
-      return result.stdout;
+    async execute(_id, { region = "cn" }) {
+      const result = await py("stock_data.py", [
+        "market_indices",
+        "--region",
+        region,
+      ]);
+      return asText(result.stdout);
     },
   });
 
@@ -239,12 +260,15 @@ export default (pi: ExtensionAPI) => {
         },
       },
     },
-    async execute({ top = 10, direction = "top" }) {
-      const result = await py(
-        "stock_data.py",
-        `sector_rankings --top ${top} --direction ${direction}`
-      );
-      return result.stdout;
+    async execute(_id, { top = 10, direction = "top" }) {
+      const result = await py("stock_data.py", [
+        "sector_rankings",
+        "--top",
+        String(top),
+        "--direction",
+        direction,
+      ]);
+      return asText(result.stdout);
     },
   });
 
@@ -262,9 +286,9 @@ export default (pi: ExtensionAPI) => {
       },
       required: ["symbol"],
     },
-    async execute({ symbol }) {
-      const result = await py("stock_data.py", `stock_info ${symbol}`);
-      return result.stdout;
+    async execute(_id, { symbol }) {
+      const result = await py("stock_data.py", ["stock_info", symbol]);
+      return asText(result.stdout);
     },
   });
 
@@ -282,9 +306,9 @@ export default (pi: ExtensionAPI) => {
       },
       required: ["symbol"],
     },
-    async execute({ symbol }) {
-      const result = await py("stock_data.py", `chip_distribution ${symbol}`);
-      return result.stdout;
+    async execute(_id, { symbol }) {
+      const result = await py("stock_data.py", ["chip_distribution", symbol]);
+      return asText(result.stdout);
     },
   });
 
@@ -302,9 +326,9 @@ export default (pi: ExtensionAPI) => {
         },
       },
     },
-    async execute({ market = "A" }) {
-      const result = await py("stock_data.py", `market_stats --market ${market}`);
-      return result.stdout;
+    async execute(_id, { market = "A" }) {
+      const result = await py("stock_data.py", ["market_stats", "--market", market]);
+      return asText(result.stdout);
     },
   });
 
@@ -322,9 +346,9 @@ export default (pi: ExtensionAPI) => {
       },
       required: ["symbol"],
     },
-    async execute({ symbol }) {
-      const result = await py("stock_data.py", `fundamental_context ${symbol}`);
-      return result.stdout;
+    async execute(_id, { symbol }) {
+      const result = await py("stock_data.py", ["fundamental_context", symbol]);
+      return asText(result.stdout);
     },
   });
 
@@ -352,13 +376,16 @@ export default (pi: ExtensionAPI) => {
         },
       },
     },
-    async execute({ market = "A", top = 20, config }) {
-      const configArg = config ? ` --config ${config}` : "";
-      const result = await py(
-        "screener.py",
-        `screen --market ${market} --top ${top}${configArg}`
-      );
-      return result.stdout;
+    async execute(_id, { market = "A", top = 20, config }) {
+      const result = await py("screener.py", [
+        "screen",
+        "--market",
+        market,
+        "--top",
+        String(top),
+        ...(config ? ["--config", config] : []),
+      ]);
+      return asText(result.stdout);
     },
   });
 
@@ -392,14 +419,17 @@ export default (pi: ExtensionAPI) => {
       },
       required: ["strategy", "symbol"],
     },
-    async execute({ strategy, symbol, start, end, capital = 1000000 }) {
-      const startArg = start ? ` --start ${start}` : "";
-      const endArg = end ? ` --end ${end}` : "";
-      const result = await py(
-        "backtest.py",
-        `run ${strategy} ${symbol}${startArg}${endArg} --capital ${capital}`
-      );
-      return result.stdout;
+    async execute(_id, { strategy, symbol, start, end, capital = 1000000 }) {
+      const result = await py("backtest.py", [
+        "run",
+        strategy,
+        symbol,
+        ...(start ? ["--start", start] : []),
+        ...(end ? ["--end", end] : []),
+        "--capital",
+        String(capital),
+      ]);
+      return asText(result.stdout);
     },
   });
 
@@ -440,12 +470,17 @@ export default (pi: ExtensionAPI) => {
       },
       required: ["symbol", "signal"],
     },
-    async execute({ symbol, signal, forward_days = "3,5,10", lookback = 250 }) {
-      const result = await py(
-        "backtest.py",
-        `evaluate_signal ${symbol} ${signal} --forward ${forward_days} --lookback ${lookback}`
-      );
-      return result.stdout;
+    async execute(_id, { symbol, signal, forward_days = "3,5,10", lookback = 250 }) {
+      const result = await py("backtest.py", [
+        "evaluate_signal",
+        symbol,
+        signal,
+        "--forward",
+        String(forward_days),
+        "--lookback",
+        String(lookback),
+      ]);
+      return asText(result.stdout);
     },
   });
 
@@ -469,12 +504,14 @@ export default (pi: ExtensionAPI) => {
       },
       required: ["query"],
     },
-    async execute({ query, top = 5 }) {
-      const result = await py(
-        "name_resolver.py",
-        `resolve "${query}" --top ${top}`
-      );
-      return result.stdout;
+    async execute(_id, { query, top = 5 }) {
+      const result = await py("name_resolver.py", [
+        "resolve",
+        query,
+        "--top",
+        String(top),
+      ]);
+      return asText(result.stdout);
     },
   });
 
@@ -499,13 +536,13 @@ export default (pi: ExtensionAPI) => {
       },
       required: ["market"],
     },
-    async execute({ market, date }) {
-      const dateArg = date ? ` --date ${date}` : "";
-      const result = await py(
-        "trading_calendar.py",
-        `check ${market}${dateArg}`
-      );
-      return result.stdout;
+    async execute(_id, { market, date }) {
+      const result = await py("trading_calendar.py", [
+        "check",
+        market,
+        ...(date ? ["--date", date] : []),
+      ]);
+      return asText(result.stdout);
     },
   });
 
@@ -537,13 +574,15 @@ export default (pi: ExtensionAPI) => {
       },
       required: ["market"],
     },
-    async execute({ market, direction = "next", count = 5, date }) {
-      const dateArg = date ? ` --date ${date}` : "";
-      const result = await py(
-        "trading_calendar.py",
-        `${direction} ${market} --count ${count}${dateArg}`
-      );
-      return result.stdout;
+    async execute(_id, { market, direction = "next", count = 5, date }) {
+      const result = await py("trading_calendar.py", [
+        direction,
+        market,
+        "--count",
+        String(count),
+        ...(date ? ["--date", date] : []),
+      ]);
+      return asText(result.stdout);
     },
   });
 
@@ -572,12 +611,18 @@ export default (pi: ExtensionAPI) => {
       },
       required: ["symbol"],
     },
-    async execute({ symbol, periods = "5,10,20,30,60,120,250", kline_period = "daily" }) {
-      const result = await py(
-        "technical.py",
-        `calculate_ma ${symbol} --periods ${periods} --period ${kline_period} --count 300`
-      );
-      return result.stdout;
+    async execute(_id, { symbol, periods = "5,10,20,30,60,120,250", kline_period = "daily" }) {
+      const result = await py("technical.py", [
+        "calculate_ma",
+        symbol,
+        "--periods",
+        periods,
+        "--period",
+        kline_period,
+        "--count",
+        "300",
+      ]);
+      return asText(result.stdout);
     },
   });
 
@@ -606,12 +651,16 @@ export default (pi: ExtensionAPI) => {
       },
       required: ["symbol"],
     },
-    async execute({ symbol, period = "daily", count = 60 }) {
-      const result = await py(
-        "volume_analysis.py",
-        `analyze ${symbol} --period ${period} --count ${count}`
-      );
-      return result.stdout;
+    async execute(_id, { symbol, period = "daily", count = 60 }) {
+      const result = await py("volume_analysis.py", [
+        "analyze",
+        symbol,
+        "--period",
+        period,
+        "--count",
+        String(count),
+      ]);
+      return asText(result.stdout);
     },
   });
 
@@ -635,12 +684,14 @@ export default (pi: ExtensionAPI) => {
       },
       required: ["query"],
     },
-    async execute({ query, count = 10 }) {
-      const result = await py(
-        "search_intel.py",
-        `search "${query}" --count ${count}`
-      );
-      return result.stdout;
+    async execute(_id, { query, count = 10 }) {
+      const result = await py("search_intel.py", [
+        "search",
+        query,
+        "--count",
+        String(count),
+      ]);
+      return asText(result.stdout);
     },
   });
 
@@ -662,13 +713,13 @@ export default (pi: ExtensionAPI) => {
       },
       required: ["symbol"],
     },
-    async execute({ symbol, name }) {
-      const nameArg = name ? ` --name "${name}"` : "";
-      const result = await py(
-        "search_intel.py",
-        `comprehensive ${symbol}${nameArg}`
-      );
-      return result.stdout;
+    async execute(_id, { symbol, name }) {
+      const result = await py("search_intel.py", [
+        "comprehensive",
+        symbol,
+        ...(name ? ["--name", name] : []),
+      ]);
+      return asText(result.stdout);
     },
   });
 
@@ -686,9 +737,9 @@ export default (pi: ExtensionAPI) => {
       },
       required: ["symbol"],
     },
-    async execute({ symbol }) {
-      const result = await py("search_intel.py", `sentiment ${symbol}`);
-      return result.stdout;
+    async execute(_id, { symbol }) {
+      const result = await py("search_intel.py", ["sentiment", symbol]);
+      return asText(result.stdout);
     },
   });
 
@@ -701,8 +752,8 @@ export default (pi: ExtensionAPI) => {
       properties: {},
     },
     async execute() {
-      const result = await py("search_intel.py", "trending");
-      return result.stdout;
+      const result = await py("search_intel.py", ["trending"]);
+      return asText(result.stdout);
     },
   });
 
@@ -720,9 +771,9 @@ export default (pi: ExtensionAPI) => {
       },
       required: ["url"],
     },
-    async execute({ url }) {
-      const result = await py("search_intel.py", `extract "${url}"`);
-      return result.stdout;
+    async execute(_id, { url }) {
+      const result = await py("search_intel.py", ["extract", url]);
+      return asText(result.stdout);
     },
   });
 
@@ -744,13 +795,13 @@ export default (pi: ExtensionAPI) => {
       },
       required: ["symbol"],
     },
-    async execute({ symbol, name }) {
-      const nameArg = name ? ` --name "${name}"` : "";
-      const result = await py(
-        "risk_screening.py",
-        `screen ${symbol}${nameArg}`,
-      );
-      return result.stdout;
+    async execute(_id, { symbol, name }) {
+      const result = await py("risk_screening.py", [
+        "screen",
+        symbol,
+        ...(name ? ["--name", name] : []),
+      ]);
+      return asText(result.stdout);
     },
   });
 
@@ -768,10 +819,10 @@ export default (pi: ExtensionAPI) => {
         },
       },
     },
-    async execute({ market }) {
+    async execute(_id, { market }) {
       const m = market || "A";
-      const result = await py("market_regime.py", `detect ${m}`);
-      return result.stdout;
+      const result = await py("market_regime.py", ["detect", m]);
+      return asText(result.stdout);
     },
   });
 
@@ -789,10 +840,10 @@ export default (pi: ExtensionAPI) => {
         },
       },
     },
-    async execute({ market }) {
+    async execute(_id, { market }) {
       const m = market || "A";
-      const result = await py("market_review.py", `review --market ${m}`);
-      return result.stdout;
+      const result = await py("market_review.py", ["review", "--market", m]);
+      return asText(result.stdout);
     },
   });
 
@@ -814,12 +865,14 @@ export default (pi: ExtensionAPI) => {
       },
       required: ["symbols"],
     },
-    async execute({ symbols, workers = 3 }) {
-      const result = await py(
-        "watchlist.py",
-        `analyze ${symbols} --workers ${workers}`
-      );
-      return result.stdout;
+    async execute(_id, { symbols, workers = 3 }) {
+      const result = await py("watchlist.py", [
+        "analyze",
+        symbols,
+        "--workers",
+        String(workers),
+      ]);
+      return asText(result.stdout);
     },
   });
 
@@ -837,9 +890,9 @@ export default (pi: ExtensionAPI) => {
       },
       required: ["symbol"],
     },
-    async execute({ symbol }) {
-      const result = await py("anomaly_detect.py", `detect ${symbol}`);
-      return result.stdout;
+    async execute(_id, { symbol }) {
+      const result = await py("anomaly_detect.py", ["detect", symbol]);
+      return asText(result.stdout);
     },
   });
 
@@ -859,9 +912,9 @@ export default (pi: ExtensionAPI) => {
         },
       },
     },
-    async execute({ market = "all" }) {
-      const result = await py("diagnostics.py", `check --market ${market}`);
-      return result.stdout;
+    async execute(_id, { market = "all" }) {
+      const result = await py("diagnostics.py", ["check", "--market", market]);
+      return asText(result.stdout);
     },
   });
 
@@ -876,10 +929,12 @@ export default (pi: ExtensionAPI) => {
         symbol: { type: "string", description: "股票代码（自动识别市场，与 market 二选一）" },
       },
     },
-    async execute({ market, symbol }) {
-      const arg = symbol ? `--symbol ${symbol}` : `--market ${market || "A"}`;
-      const result = await py("capabilities.py", `get ${arg}`);
-      return result.stdout;
+    async execute(_id, { market, symbol }) {
+      const args = symbol
+        ? ["get", "--symbol", symbol]
+        : ["get", "--market", market || "A"];
+      const result = await py("capabilities.py", args);
+      return asText(result.stdout);
     },
   });
 
@@ -904,13 +959,16 @@ export default (pi: ExtensionAPI) => {
       },
       required: ["report"],
     },
-    async execute({ report, template = "full" }) {
+    async execute(_id, { report, template = "full" }) {
       const b64 = Buffer.from(JSON.stringify(report), "utf-8").toString("base64");
-      const result = await py(
-        "report_renderer.py",
-        `stock --template ${template} --input-b64 ${b64}`
-      );
-      return result.stdout;
+      const result = await py("report_renderer.py", [
+        "stock",
+        "--template",
+        template,
+        "--input-b64",
+        b64,
+      ]);
+      return asText(result.stdout);
     },
   });
 
@@ -926,13 +984,16 @@ export default (pi: ExtensionAPI) => {
       },
       required: ["report"],
     },
-    async execute({ report, template = "full" }) {
+    async execute(_id, { report, template = "full" }) {
       const b64 = Buffer.from(JSON.stringify(report), "utf-8").toString("base64");
-      const result = await py(
-        "report_renderer.py",
-        `market --template ${template} --input-b64 ${b64}`
-      );
-      return result.stdout;
+      const result = await py("report_renderer.py", [
+        "market",
+        "--template",
+        template,
+        "--input-b64",
+        b64,
+      ]);
+      return asText(result.stdout);
     },
   });
 
@@ -954,13 +1015,15 @@ export default (pi: ExtensionAPI) => {
       },
       required: ["symbols"],
     },
-    async execute({ symbols, include_market_review = false, workers = 3 }) {
-      const flag = include_market_review ? " --include-market-review" : "";
-      const result = await py(
-        "watchlist_context.py",
-        `build ${symbols} --workers ${workers}${flag}`
-      );
-      return result.stdout;
+    async execute(_id, { symbols, include_market_review = false, workers = 3 }) {
+      const result = await py("watchlist_context.py", [
+        "build",
+        symbols,
+        "--workers",
+        String(workers),
+        ...(include_market_review ? ["--include-market-review"] : []),
+      ]);
+      return asText(result.stdout);
     },
   });
 
@@ -979,14 +1042,18 @@ export default (pi: ExtensionAPI) => {
       },
       required: ["symbol", "cost", "quantity"],
     },
-    async execute({ symbol, cost, quantity, stop_loss, take_profit }) {
-      const slArg = stop_loss !== undefined ? ` --stop-loss ${stop_loss}` : "";
-      const tpArg = take_profit !== undefined ? ` --take-profit ${take_profit}` : "";
-      const result = await py(
-        "position_context.py",
-        `analyze ${symbol} --cost ${cost} --quantity ${quantity}${slArg}${tpArg}`
-      );
-      return result.stdout;
+    async execute(_id, { symbol, cost, quantity, stop_loss, take_profit }) {
+      const result = await py("position_context.py", [
+        "analyze",
+        symbol,
+        "--cost",
+        String(cost),
+        "--quantity",
+        String(quantity),
+        ...(stop_loss !== undefined ? ["--stop-loss", String(stop_loss)] : []),
+        ...(take_profit !== undefined ? ["--take-profit", String(take_profit)] : []),
+      ]);
+      return asText(result.stdout);
     },
   });
 
@@ -1012,10 +1079,10 @@ export default (pi: ExtensionAPI) => {
       },
       required: ["symbol", "rules"],
     },
-    async execute({ symbol, rules }) {
+    async execute(_id, { symbol, rules }) {
       const b64 = Buffer.from(JSON.stringify(rules), "utf-8").toString("base64");
-      const result = await py("alert_rules.py", `check ${symbol} --rules-b64 ${b64}`);
-      return result.stdout;
+      const result = await py("alert_rules.py", ["check", symbol, "--rules-b64", b64]);
+      return asText(result.stdout);
     },
   });
 
@@ -1030,10 +1097,10 @@ export default (pi: ExtensionAPI) => {
       },
       required: ["text"],
     },
-    async execute({ text }) {
+    async execute(_id, { text }) {
       const b64 = Buffer.from(String(text), "utf-8").toString("base64");
-      const result = await py("import_parser.py", `parse --text-b64 ${b64}`);
-      return result.stdout;
+      const result = await py("import_parser.py", ["parse", "--text-b64", b64]);
+      return asText(result.stdout);
     },
   });
 

--- a/pi/index.ts
+++ b/pi/index.ts
@@ -14,13 +14,13 @@ export default (pi: ExtensionAPI) => {
   pi.registerTool({
     name: "get_kline",
     description:
-      "获取股票K线数据（OHLCV）。支持A股（如600519）、港股（如00700.HK）、美股（如AAPL）",
+      "获取股票K线数据（OHLCV）。支持A股（如600519）、港股（如00700.HK）、美股（如AAPL）、日股（如7203.T）、韩股（如005930.KS）、台股（如2330.TW）及A股ETF",
     parameters: {
       type: "object",
       properties: {
         symbol: {
           type: "string",
-          description: "股票代码，如 600519（A股）、00700.HK（港股）、AAPL（美股）",
+          description: "股票代码，如 600519（A股）、00700.HK（港股）、AAPL（美股）、7203.T（日股）、005930.KS（韩股）、2330.TW（台股）",
         },
         period: {
           type: "string",
@@ -46,7 +46,7 @@ export default (pi: ExtensionAPI) => {
   pi.registerTool({
     name: "get_quote",
     description:
-      "获取股票实时行情报价。支持A股、港股、美股",
+      "获取股票实时行情报价。支持A股、港股、美股、日股、韩股、台股",
     parameters: {
       type: "object",
       properties: {
@@ -202,13 +202,13 @@ export default (pi: ExtensionAPI) => {
   pi.registerTool({
     name: "get_market_indices",
     description:
-      "获取主要市场指数行情。CN: 上证/深证/创业板/科创50/沪深300；HK: 恒生/国企/科技；US: 道琼斯/纳斯达克/标普500",
+      "获取主要市场指数行情。CN: 上证/深证/创业板/科创50/沪深300；HK: 恒生/国企/科技；US: 道琼斯/纳斯达克/标普500；JP: 日经225/东证；KR: KOSPI/KOSDAQ；TW: 台湾加权",
     parameters: {
       type: "object",
       properties: {
         region: {
           type: "string",
-          enum: ["cn", "hk", "us"],
+          enum: ["cn", "hk", "us", "jp", "kr", "tw"],
           description: "市场区域，默认 cn",
         },
       },
@@ -251,7 +251,7 @@ export default (pi: ExtensionAPI) => {
   pi.registerTool({
     name: "get_stock_info",
     description:
-      "获取股票基本信息（行业、板块、上市日期、总股本等）。A股返回板块/行业，HK/US返回行业/公司简介",
+      "获取股票基本信息（行业、板块、上市日期、总股本等）。A股返回板块/行业，其他市场返回行业/公司简介",
     parameters: {
       type: "object",
       properties: {
@@ -483,13 +483,13 @@ export default (pi: ExtensionAPI) => {
   pi.registerTool({
     name: "check_trading_day",
     description:
-      "查询某日是否为交易日。支持CN（A股）、HK（港股）、US（美股）三市场",
+      "查询某日是否为交易日。支持CN（A股）、HK（港股）、US（美股）、JP（日股）、KR（韩股）、TW（台股）",
     parameters: {
       type: "object",
       properties: {
         market: {
           type: "string",
-          enum: ["CN", "HK", "US"],
+          enum: ["CN", "HK", "US", "JP", "KR", "TW"],
           description: "市场",
         },
         date: {
@@ -512,13 +512,13 @@ export default (pi: ExtensionAPI) => {
   pi.registerTool({
     name: "get_trading_days",
     description:
-      "获取最近/未来N个交易日列表。支持CN/HK/US三市场",
+      "获取最近/未来N个交易日列表。支持CN/HK/US/JP/KR/TW",
     parameters: {
       type: "object",
       properties: {
         market: {
           type: "string",
-          enum: ["CN", "HK", "US"],
+          enum: ["CN", "HK", "US", "JP", "KR", "TW"],
           description: "市场",
         },
         direction: {
@@ -854,7 +854,7 @@ export default (pi: ExtensionAPI) => {
       properties: {
         market: {
           type: "string",
-          enum: ["A", "HK", "US", "all"],
+          enum: ["A", "HK", "US", "JP", "KR", "TW", "all"],
           description: "市场，默认 all",
         },
       },
@@ -872,7 +872,7 @@ export default (pi: ExtensionAPI) => {
     parameters: {
       type: "object",
       properties: {
-        market: { type: "string", enum: ["A", "HK", "US"], description: "市场代码" },
+        market: { type: "string", enum: ["A", "HK", "US", "JP", "KR", "TW"], description: "市场代码" },
         symbol: { type: "string", description: "股票代码（自动识别市场，与 market 二选一）" },
       },
     },
@@ -1022,7 +1022,7 @@ export default (pi: ExtensionAPI) => {
   pi.registerTool({
     name: "parse_stock_list",
     description:
-      "自选股/文本导入解析 — 从自然语言、CSV、Markdown 表格提取股票，自动识别 A 股 6 位代码、港股 xxxxx.HK、美股 ticker，并调用 name_resolver 处理中文股票名",
+      "自选股/文本导入解析 — 从自然语言、CSV、Markdown 表格提取股票，自动识别 A 股 6 位代码、港股 xxxxx.HK、美股 ticker、日股 xxxx.T、韩股 xxxxxx.KS/KQ、台股 xxxx.TW，并调用 name_resolver 处理中文股票名",
     parameters: {
       type: "object",
       properties: {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "stock-analysis-plugin"
 version = "0.1.4"
-description = "Hermes plugin for stock analysis, screening, and strategy backtesting across A/HK/US markets"
+description = "Hermes plugin for stock analysis, screening, and strategy backtesting across A/HK/US/JP/KR/TW markets"
 readme = "README.md"
 requires-python = ">=3.10"
 license = "MIT"
@@ -55,7 +55,7 @@ Repository = "https://github.com/Weaxs/stock-analysis-plugin"
 Issues = "https://github.com/Weaxs/stock-analysis-plugin/issues"
 
 [project.entry-points."hermes_agent.plugins"]
-stock-analysis = "hermes:register"
+stock-analysis = "hermes"
 
 [build-system]
 requires = ["hatchling"]

--- a/tests/e2e/host_smoke.mjs
+++ b/tests/e2e/host_smoke.mjs
@@ -1,0 +1,241 @@
+#!/usr/bin/env node
+/**
+ * Real-host smoke QA: install the plugin into a real host runtime and run one
+ * QA turn through the host's own agent loop.
+ *
+ * Usage: node tests/e2e/host_smoke.mjs <pi|openclaw|hermes>
+ *
+ * Env:
+ *   SMOKE_LLM_API_KEY  (required) API key for the QA model
+ *   SMOKE_LLM_BASE_URL (required) OpenAI-compatible base URL
+ *   SMOKE_LLM_MODEL    (optional) default: deepseek-v4-flash
+ *   SMOKE_WORKDIR      (optional) scratch dir, default: mktemp
+ *
+ * Assertions (both required, retried up to 2 times):
+ *   1. the host actually invoked our get_quote tool (tool-call trace)
+ *   2. the final answer contains a number (real data reached the reply)
+ */
+import { execFileSync, execSync, execFile } from "node:child_process";
+import { mkdtempSync, readFileSync, readdirSync, existsSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..");
+import { dirname } from "node:path";
+
+const host = process.argv[2];
+if (!["pi", "openclaw", "hermes"].includes(host)) {
+  console.error("usage: host_smoke.mjs <pi|openclaw|hermes>");
+  process.exit(2);
+}
+
+const API_KEY = process.env.SMOKE_LLM_API_KEY || "";
+const BASE_URL = process.env.SMOKE_LLM_BASE_URL || "";
+const MODEL = process.env.SMOKE_LLM_MODEL || "deepseek-v4-flash";
+const PROVIDER = process.env.SMOKE_LLM_PROVIDER || "deepseek";
+if (!API_KEY || !BASE_URL) {
+  console.error("SMOKE_LLM_API_KEY and SMOKE_LLM_BASE_URL are required");
+  process.exit(2);
+}
+
+const WORK = process.env.SMOKE_WORKDIR || mkdtempSync(join(tmpdir(), `host-smoke-${host}-`));
+const QUESTION =
+  "Use the get_quote tool to check AAPL's latest price. Reply with only the price number.";
+const MAX_ATTEMPTS = 2;
+
+function sh(cmd, args, opts = {}) {
+  console.log(`+ ${cmd} ${args.join(" ")}`.slice(0, 160));
+  return execFileSync(cmd, args, {
+    maxBuffer: 64 * 1024 * 1024,
+    stdio: ["ignore", "pipe", "pipe"],
+    ...opts,
+  }).toString();
+}
+
+function assertCond(cond, msg) {
+  if (!cond) throw new Error(`assert failed: ${msg}`);
+}
+
+function findPython() {
+  const candidates = [process.env.SMOKE_PYTHON, "python3.13", "python3.12", "python3.11", "python3"].filter(Boolean);
+  for (const c of candidates) {
+    try {
+      const out = execFileSync(c, ["--version"], { stdio: ["ignore", "pipe", "pipe"] }).toString();
+      const m = out.match(/(\d+)\.(\d+)/);
+      if (m && (Number(m[1]) > 3 || (Number(m[1]) === 3 && Number(m[2]) >= 11))) return c;
+    } catch { /* try next */ }
+  }
+  throw new Error("python >= 3.11 not found (set SMOKE_PYTHON)");
+}
+
+// ---------------------------------------------------------------- pi -------
+async function smokePi() {
+  // Real install path: project-local `pi install <repo>` records the package in
+  // .pi/settings.json; --approve bypasses the interactive project-trust prompt.
+  sh("pi", ["install", repoRoot, "-l"], { cwd: WORK });
+  const list = sh("pi", ["list", "--approve"], { cwd: WORK });
+  assertCond(/stock-analysis/i.test(list), "pi list should show the installed package");
+
+  let lastOut = "";
+  for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+    const out = sh(
+      "pi",
+      [
+        "--approve", "-p", "--mode", "json", "--no-session",
+        "--provider", PROVIDER, "--model", MODEL, "--api-key", API_KEY,
+        QUESTION,
+      ],
+      { cwd: WORK }
+    );
+    lastOut = out;
+    const calledGetQuote = out.includes('"toolName":"get_quote"');
+    // last assistant text in the NDJSON stream
+    let finalText = "";
+    for (const line of out.split("\n")) {
+      if (!line.trim()) continue;
+      try {
+        const ev = JSON.parse(line);
+        if (ev.type === "message_end" && ev.message?.role === "assistant") {
+          const text = (ev.message.content || [])
+            .filter((c) => c.type === "text")
+            .map((c) => c.text)
+            .join("");
+          if (text.trim()) finalText = text;
+        }
+      } catch { /* partial lines */ }
+    }
+    console.log(`attempt ${attempt}: toolCalled=${calledGetQuote} final=${finalText.slice(0, 80)}`);
+    if (calledGetQuote && /\d/.test(finalText)) return;
+  }
+  throw new Error(`pi smoke failed; last output tail:\n${lastOut.slice(-800)}`);
+}
+
+// ----------------------------------------------------------- openclaw -------
+function smokeOpenclaw() {
+  // Replicate the publish payload: stage shared dirs, build dist, pack, install.
+  for (const d of ["tools", "skills", "schemas", "templates", "strategies", "scripts"]) {
+    sh("rm", ["-rf", join(repoRoot, "openclaw", d)]);
+    sh("cp", ["-R", join(repoRoot, d), join(repoRoot, "openclaw", d)]);
+  }
+  sh("npm", ["run", "build:openclaw"], { cwd: repoRoot });
+  const packOut = sh("npm", ["pack"], { cwd: join(repoRoot, "openclaw") });
+  const tgz = join(repoRoot, "openclaw", packOut.trim().split("\n").pop());
+
+  const oc = (args, opts = {}) =>
+    sh("openclaw", ["--profile", "ci-smoke", ...args], opts);
+  oc(["plugins", "install", tgz, "--force"]);
+  const extDir = join(process.env.HOME, ".openclaw-ci-smoke", "extensions", "stock-analysis");
+  assertCond(existsSync(join(extDir, "dist", "index.js")), "installed plugin has dist/index.js");
+  assertCond(existsSync(join(extDir, "tools", "stock_data.py")), "installed plugin has tools/");
+
+  // Lifecycle scripts don't run on plugin install — set the python env up like
+  // the docs tell users to.
+  if (!existsSync(join(extDir, ".venv"))) {
+    sh("node", [join(extDir, "scripts", "setup-python.mjs")], { cwd: extDir });
+  }
+
+  // DeepSeek via openai-completions custom provider.
+  oc([
+    "config", "set", "models.providers.smokellm",
+    JSON.stringify({
+      baseUrl: BASE_URL,
+      apiKey: API_KEY,
+      api: "openai-completions",
+      models: [{
+        id: MODEL, name: MODEL, reasoning: false, input: ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 128000, maxTokens: 8192,
+      }],
+    }),
+    "--strict-json",
+  ]);
+  oc(["config", "set", "agents.defaults.model.primary", `smokellm/${MODEL}`]);
+
+  let lastText = "";
+  for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+    const sessionId = `smoke-${Date.now()}`;
+    const out = oc([
+      "agent", "--local", "--session-id", sessionId,
+      "-m", QUESTION, "--json", "--timeout", "180",
+    ]);
+    const parsed = JSON.parse(out);
+    const text = (parsed.payloads || []).map((p) => p.text || "").join("\n");
+    lastText = text;
+    // tool-call trace lives in the session transcript file
+    const sessionFile = parsed.meta?.agentMeta?.sessionFile;
+    let calledGetQuote = false;
+    if (sessionFile && existsSync(sessionFile)) {
+      calledGetQuote = readFileSync(sessionFile, "utf-8").includes("get_quote");
+    }
+    console.log(`attempt ${attempt}: toolCalled=${calledGetQuote} final=${text.slice(0, 80)}`);
+    if (calledGetQuote && /\d/.test(text)) return;
+  }
+  throw new Error(`openclaw smoke failed; last answer:\n${lastText.slice(-800)}`);
+}
+
+// ------------------------------------------------------------- hermes -------
+function smokeHermes() {
+  const venv = join(WORK, "venv");
+  sh(findPython(), ["-m", "venv", venv]);
+  const pip = join(venv, "bin", "pip");
+  const hermes = join(venv, "bin", "hermes");
+  sh(pip, ["install", "--quiet", "--upgrade", "pip"]);
+  sh(pip, ["install", "--quiet", "hermes-agent"]);
+  sh(pip, ["install", "--quiet", repoRoot]);
+  // handlers shell out to "python3" — make it resolve to this venv, which has
+  // the full data-source deps (yfinance etc.) from tools/requirements.txt
+  sh(pip, ["install", "--quiet", "-r", join(repoRoot, "tools", "requirements.txt")]);
+
+  const plugins = sh(hermes, ["plugins", "list"]);
+  assertCond(/stock-analysis/.test(plugins), "hermes plugins list should show stock-analysis");
+  sh(hermes, ["plugins", "enable", "stock-analysis", "--no-allow-tool-override"]);
+
+  const env = {
+    ...process.env,
+    PATH: `${join(venv, "bin")}:${process.env.PATH}`,
+    DEEPSEEK_API_KEY: API_KEY,
+    DEEPSEEK_BASE_URL: BASE_URL,
+    KIMI_API_KEY: API_KEY,
+    KIMI_BASE_URL: BASE_URL,
+    OPENAI_API_KEY: API_KEY,
+    OPENAI_BASE_URL: BASE_URL,
+  };
+  let lastOut = "";
+  for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+    const usageFile = join(WORK, `hermes-usage-${attempt}.json`);
+    const out = execFileSync(
+      hermes,
+      [
+        "-z", QUESTION,
+        "-m", MODEL,
+        "--provider", PROVIDER,
+        "-t", "stock-analysis",
+        "--usage-file", usageFile,
+      ],
+      { env, maxBuffer: 64 * 1024 * 1024, stdio: ["ignore", "pipe", "pipe"] }
+    ).toString();
+    lastOut = out;
+    // oneshot prints the final response only; tool usage is asserted via the
+    // usage report: a tool round-trip means >= 2 API calls
+    const usage = JSON.parse(readFileSync(usageFile, "utf-8"));
+    const toolRoundTrip = usage.completed === true && usage.failed === false && usage.api_calls >= 2;
+    const hasNumber = /\d{2,}/.test(out);
+    console.log(
+      `attempt ${attempt}: apiCalls=${usage.api_calls} numeric=${hasNumber} out=${out.trim().slice(0, 60)}`
+    );
+    if (toolRoundTrip && hasNumber) return;
+  }
+  throw new Error(`hermes smoke failed; last output:\n${lastOut.slice(-800)}`);
+}
+
+const runners = { pi: smokePi, openclaw: smokeOpenclaw, hermes: smokeHermes };
+try {
+  await runners[host]();
+  console.log(`\nOK: ${host} real-host smoke passed`);
+} catch (err) {
+  console.error(`\nFAIL: ${host} real-host smoke: ${err.message}`);
+  process.exit(1);
+}

--- a/tests/e2e/test_host_to_python.py
+++ b/tests/e2e/test_host_to_python.py
@@ -80,7 +80,7 @@ class TestDiagnoseDataSourcesRoundTrip:
         out = _run_cli("diagnostics.py", ["check", "--market", "all"])
         assert out["meta"]["provider"] == "diagnostics"
         markets = {m["market"] for m in out["markets"]}
-        assert markets == {"A", "HK", "US"}
+        assert markets == {"A", "HK", "US", "JP", "KR", "TW"}
 
 
 # ---------------------------------------------------------------------------

--- a/tests/e2e/test_pi_e2e.ts
+++ b/tests/e2e/test_pi_e2e.ts
@@ -26,9 +26,13 @@ const python = existsSync(venvPython) ? venvPython : "python3";
 
 // --- Load pi/index.ts and capture the tool registrations ------------------
 
+interface ToolResult {
+  content: { type: string; text: string }[];
+  details: unknown;
+}
 interface Registered {
   name: string;
-  execute: (args: Record<string, unknown>) => Promise<string>;
+  execute: (toolCallId: string, args: Record<string, unknown>) => Promise<ToolResult>;
 }
 const registered: Registered[] = [];
 
@@ -37,16 +41,12 @@ const mockPi = {
     registered.push(cfg);
   },
   on() {},
-  exec: async (cmd: string) => {
-    // The `py()` helper inside pi/index.ts calls pi.exec with a full command string.
-    // Real subprocess execution goes here.
-    const parts = cmd.split(/\s+/);
-    const bin = parts[0];
-    const argv = parts.slice(1);
-    const { stdout, stderr } = await execFileAsync(bin, argv, {
+  exec: async (cmd: string, args: string[] = []) => {
+    // pi/index.ts calls pi.exec(python, [script, ...args]) — argv form, no shell.
+    const { stdout, stderr } = await execFileAsync(cmd, args, {
       maxBuffer: 32 * 1024 * 1024,
     });
-    return { stdout, stderr, exitCode: 0 };
+    return { stdout, stderr, code: 0, killed: false };
   },
 };
 
@@ -72,8 +72,8 @@ function assert(cond: boolean, msg: string) {
 async function callTool(name: string, args: Record<string, unknown>): Promise<any> {
   const tool = registered.find((t) => t.name === name);
   if (!tool) throw new Error(`tool not registered: ${name}`);
-  const raw = await tool.execute(args);
-  return JSON.parse(raw);
+  const result = await tool.execute("e2e-call", args);
+  return JSON.parse(result.content[0].text);
 }
 
 console.log(`Pi e2e host→python round-trip (python: ${python})`);

--- a/tests/e2e/test_pi_llm.ts
+++ b/tests/e2e/test_pi_llm.ts
@@ -33,11 +33,15 @@ const python = existsSync(venvPython) ? venvPython : "python3";
 
 // --- Load Pi and capture tool registrations -------------------------------
 
+interface ToolResult {
+  content: { type: string; text: string }[];
+  details: unknown;
+}
 interface Registered {
   name: string;
   description: string;
   parameters: Record<string, unknown>;
-  execute: (args: Record<string, unknown>) => Promise<string>;
+  execute: (toolCallId: string, args: Record<string, unknown>) => Promise<ToolResult>;
 }
 const registered: Registered[] = [];
 
@@ -46,14 +50,11 @@ const mockPi = {
     registered.push(cfg);
   },
   on() {},
-  exec: async (cmd: string) => {
-    const parts = cmd.split(/\s+/);
-    const bin = parts[0];
-    const argv = parts.slice(1);
-    const { stdout, stderr } = await execFileAsync(bin, argv, {
+  exec: async (cmd: string, args: string[] = []) => {
+    const { stdout, stderr } = await execFileAsync(cmd, args, {
       maxBuffer: 32 * 1024 * 1024,
     });
-    return { stdout, stderr, exitCode: 0 };
+    return { stdout, stderr, code: 0, killed: false };
   },
 };
 
@@ -111,7 +112,7 @@ async function runLoop(userMsg: string, toolNames: string[], maxTurns = 3) {
 
       const tool = registered.find((r) => r.name === name);
       const rawResult = tool
-        ? await tool.execute(args)
+        ? (await tool.execute(call.id, args)).content[0]?.text ?? ""
         : JSON.stringify({ error: "unknown tool" });
 
       let parsedResult: any = null;

--- a/tests/test_capabilities.py
+++ b/tests/test_capabilities.py
@@ -43,3 +43,24 @@ if __name__ == "__main__":
 
     r = subprocess.run([sys.executable, "-m", "pytest", __file__, "-q"], cwd=os.path.dirname(os.path.dirname(__file__)))
     sys.exit(r.returncode)
+
+
+class TestNewMarkets:
+    def test_jp_supports_generic_tools(self):
+        result = capabilities.get_capabilities("JP")
+        for tool in ("get_kline", "get_quote", "get_news", "get_financials", "get_market_indices"):
+            assert tool in result["supported"]
+
+    def test_jp_rejects_a_share_only_and_regime(self):
+        result = capabilities.get_capabilities("JP")
+        unsupported = {u["tool"] for u in result["unsupported"]}
+        assert "get_chip_distribution" in unsupported
+        assert "get_capital_flow" in unsupported
+        assert "detect_market_regime" in unsupported
+        assert "get_market_review" in unsupported
+
+    def test_kr_tw_supported(self):
+        for m in ("KR", "TW"):
+            result = capabilities.get_capabilities(m)
+            assert "get_kline" in result["supported"]
+            assert "get_quote" in result["supported"]

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -71,7 +71,7 @@ class TestDiagnose:
         monkeypatch.delenv("FINNHUB_API_KEY", raising=False)
         result = diagnostics.diagnose("all")
         markets = {m["market"] for m in result["markets"]}
-        assert markets == {"A", "HK", "US"}
+        assert markets == {"A", "HK", "US", "JP", "KR", "TW"}
         assert "meta" in result
         assert result["meta"]["provider"] == "diagnostics"
 

--- a/tests/test_import_parser.py
+++ b/tests/test_import_parser.py
@@ -91,3 +91,33 @@ if __name__ == "__main__":
 
     r = subprocess.run([sys.executable, "-m", "pytest", __file__, "-q"], cwd=os.path.dirname(os.path.dirname(__file__)))
     sys.exit(r.returncode)
+
+
+class TestAsiaSuffixCodes:
+    def test_jp_kr_tw_codes(self, monkeypatch):
+        monkeypatch.setattr(import_parser, "resolve", lambda name, top=1: [])
+        result = import_parser.parse("7203.T 005930.KS 2330.TW")
+        markets = {i["symbol"]: i["market"] for i in result["items"]}
+        assert markets["7203.T"] == "JP"
+        assert markets["005930.KS"] == "KR"
+        assert markets["2330.TW"] == "TW"
+
+    def test_suffix_digits_not_misread_as_a_share(self, monkeypatch):
+        monkeypatch.setattr(import_parser, "resolve", lambda name, top=1: [])
+        result = import_parser.parse("005930.KS")
+        syms = {i["symbol"] for i in result["items"]}
+        assert "005930" not in syms
+
+    def test_suffix_not_misread_as_us_ticker(self, monkeypatch):
+        monkeypatch.setattr(import_parser, "resolve", lambda name, top=1: [])
+        result = import_parser.parse("00700.HK 2330.TW")
+        syms = {i["symbol"] for i in result["items"]}
+        assert "HK" not in syms
+        assert "TW" not in syms
+
+    def test_kq_and_two_suffixes(self, monkeypatch):
+        monkeypatch.setattr(import_parser, "resolve", lambda name, top=1: [])
+        result = import_parser.parse("035720.KQ 6510.TWO")
+        markets = {i["symbol"]: i["market"] for i in result["items"]}
+        assert markets["035720.KQ"] == "KR"
+        assert markets["6510.TWO"] == "TW"

--- a/tests/test_search_intel.py
+++ b/tests/test_search_intel.py
@@ -1,0 +1,75 @@
+"""Tests for tools/search_intel.py — web search engines (incl. SearXNG fallback)."""
+
+import sys
+from unittest.mock import MagicMock, patch
+
+from tools.search_intel import _searxng_search, search_news
+
+
+def _mock_requests(payload, ok=True):
+    mock_resp = MagicMock()
+    mock_resp.ok = ok
+    mock_resp.json.return_value = payload
+    mock_req = MagicMock()
+    mock_req.get.return_value = mock_resp
+    mock_req.post.return_value = mock_resp
+    return mock_req
+
+
+class TestSearxngSearch:
+    @patch.dict("os.environ", {}, clear=True)
+    def test_no_base_urls_returns_empty(self):
+        assert _searxng_search("test query") == []
+
+    @patch.dict("os.environ", {"SEARXNG_BASE_URLS": "http://127.0.0.1:8080"})
+    def test_parses_results(self):
+        payload = {
+            "results": [
+                {"title": "T1", "url": "http://a.com/1", "content": "snippet one"},
+                {"title": "T2", "url": "http://a.com/2", "content": "snippet two"},
+            ]
+        }
+        with patch.dict(sys.modules, {"requests": _mock_requests(payload)}):
+            results = _searxng_search("600519 最新消息")
+        assert len(results) == 2
+        assert results[0]["source"] == "searxng"
+        assert results[0]["title"] == "T1"
+        assert results[0]["url"] == "http://a.com/1"
+
+    @patch.dict("os.environ", {"SEARXNG_BASE_URLS": "http://bad1:8080, http://good:8080/"})
+    def test_fails_over_to_next_instance(self):
+        payload = {"results": [{"title": "T", "url": "http://a.com", "content": "c"}]}
+        mock_req = MagicMock()
+        bad_resp = MagicMock(ok=False)
+        good_resp = MagicMock(ok=True)
+        good_resp.json.return_value = payload
+        mock_req.get.side_effect = [bad_resp, good_resp]
+        with patch.dict(sys.modules, {"requests": mock_req}):
+            results = _searxng_search("query")
+        assert len(results) == 1
+        # trailing slash stripped before building the URL
+        assert mock_req.get.call_args[0][0] == "http://good:8080/search"
+
+    @patch.dict("os.environ", {"SEARXNG_BASE_URLS": "http://127.0.0.1:8080"})
+    def test_exception_returns_empty(self):
+        mock_req = MagicMock()
+        mock_req.get.side_effect = Exception("network down")
+        with patch.dict(sys.modules, {"requests": mock_req}):
+            assert _searxng_search("query") == []
+
+
+class TestSearchNewsSearxngFallback:
+    @patch.dict("os.environ", {"SEARXNG_BASE_URLS": "http://sx:8080"}, clear=True)
+    def test_searxng_used_as_last_resort(self):
+        payload = {"results": [{"title": "T", "url": "http://a.com", "content": "c"}]}
+        with patch.dict(sys.modules, {"requests": _mock_requests(payload)}):
+            result = search_news("some query")
+        assert result["engines_used"] == ["searxng"]
+        assert result["results"][0]["source"] == "searxng"
+
+    @patch.dict("os.environ", {}, clear=True)
+    def test_note_mentions_searxng_when_nothing_configured(self):
+        with patch.dict(sys.modules, {"requests": MagicMock()}):
+            result = search_news("some query")
+        assert result["results"] == []
+        assert "SEARXNG_BASE_URLS" in result["note"]

--- a/tests/test_stock_data.py
+++ b/tests/test_stock_data.py
@@ -17,6 +17,18 @@ class TestDetectMarket:
         assert detect_market("TSLA") == "US"
         assert detect_market("MSFT") == "US"
 
+    def test_jp(self):
+        assert detect_market("7203.T") == "JP"
+        assert detect_market("6758.t") == "JP"
+
+    def test_kr(self):
+        assert detect_market("005930.KS") == "KR"
+        assert detect_market("035720.KQ") == "KR"
+
+    def test_tw(self):
+        assert detect_market("2330.TW") == "TW"
+        assert detect_market("6510.TWO") == "TW"
+
 
 class TestNormalizeStockCode:
     def test_main_board(self):

--- a/tests/test_stock_data_failover.py
+++ b/tests/test_stock_data_failover.py
@@ -11,6 +11,7 @@ import pytest
 from tools.stock_data import (
     _capital_flow_efinance,
     _failover,
+    _kline_akshare,
     _kline_alphavantage,
     _kline_finnhub,
     _kline_longbridge,
@@ -870,3 +871,117 @@ class TestKlineYfFailoverExtended:
         with pytest.raises(ValueError, match="down"):
             kline_yf("0700.HK", "daily", 10)
         mock_av.assert_not_called()
+
+
+class TestNewMarketKlineChain:
+    """JP/KR/TW kline/quote should use yfinance only — finnhub/longbridge/alphavantage don't cover them."""
+
+    @patch("tools.stock_data._kline_finnhub")
+    @patch("tools.stock_data._kline_yfinance")
+    def test_jp_kline_yfinance_only(self, mock_yf, mock_fh):
+        mock_yf.return_value = [{"close": 100}]
+        result = kline_yf("7203.T", "daily", 10)
+        assert result == [{"close": 100}]
+        mock_fh.assert_not_called()
+
+    @patch("tools.stock_data._kline_finnhub")
+    @patch("tools.stock_data._kline_yfinance")
+    def test_kr_kline_no_finnhub_fallback(self, mock_yf, mock_fh):
+        mock_yf.side_effect = ValueError("yf down")
+        mock_fh.return_value = [{"close": 200}]
+        with pytest.raises(ValueError, match="yf down"):
+            kline_yf("005930.KS", "daily", 10)
+        mock_fh.assert_not_called()
+
+    @patch("tools.stock_data._quote_finnhub")
+    @patch("tools.stock_data._quote_yfinance")
+    def test_tw_quote_no_finnhub_fallback(self, mock_yf, mock_fh):
+        mock_yf.side_effect = ValueError("yf down")
+        mock_fh.return_value = {"price": 1000}
+        with pytest.raises(ValueError, match="yf down"):
+            quote_yf("2330.TW")
+        mock_fh.assert_not_called()
+
+    @patch("tools.stock_data._quote_finnhub")
+    @patch("tools.stock_data._quote_yfinance")
+    def test_hk_quote_still_has_finnhub_fallback(self, mock_yf, mock_fh):
+        mock_yf.side_effect = ValueError("yf down")
+        mock_fh.return_value = {"price": 500}
+        assert quote_yf("0700.HK") == {"price": 500}
+
+
+class TestAkshareETF:
+    """A-share ETFs (51/15xxxx etc.) must route to fund APIs, not stock APIs."""
+
+    def _etf_hist_df(self):
+        import pandas as pd
+
+        return pd.DataFrame(
+            {
+                "日期": ["2026-01-05", "2026-01-06"],
+                "开盘": [4.0, 4.1],
+                "收盘": [4.05, 4.15],
+                "最高": [4.1, 4.2],
+                "最低": [3.9, 4.0],
+                "成交量": [100000, 200000],
+                "成交额": [400000.0, 800000.0],
+                "涨跌幅": [1.25, 2.47],
+                "换手率": [3.0, 5.0],
+            }
+        )
+
+    def test_etf_kline_uses_fund_api(self):
+        mock_ak = MagicMock()
+        mock_ak.fund_etf_hist_em.return_value = self._etf_hist_df()
+        mock_ak.stock_zh_a_hist.side_effect = AssertionError("stock api must not be called for ETF")
+        with patch.dict(sys.modules, {"akshare": mock_ak}):
+            result = _kline_akshare("510300", "daily", 2)
+        assert len(result) == 2
+        assert result[0]["close"] == 4.05
+        mock_ak.fund_etf_hist_em.assert_called_once()
+
+    def test_stock_kline_still_uses_stock_api(self):
+        mock_ak = MagicMock()
+        mock_ak.stock_zh_a_hist.return_value = self._etf_hist_df()
+        mock_ak.fund_etf_hist_em.side_effect = AssertionError("fund api must not be called for stock")
+        with patch.dict(sys.modules, {"akshare": mock_ak}):
+            result = _kline_akshare("600519", "daily", 2)
+        assert len(result) == 2
+        mock_ak.stock_zh_a_hist.assert_called_once()
+
+    def test_etf_quote_uses_fund_spot(self):
+        import pandas as pd
+
+        mock_ak = MagicMock()
+        mock_ak.fund_etf_spot_em.return_value = pd.DataFrame(
+            {
+                "代码": ["510300"],
+                "名称": ["沪深300ETF"],
+                "最新价": [4.05],
+                "涨跌幅": [1.25],
+                "成交量": [100000],
+                "成交额": [400000.0],
+                "开盘价": [4.0],
+                "最高价": [4.1],
+                "最低价": [3.9],
+                "昨收": [4.0],
+                "换手率": [3.0],
+            }
+        )
+        mock_ak.stock_zh_a_spot_em.side_effect = AssertionError("stock spot must not be called first for ETF")
+        with patch.dict(sys.modules, {"akshare": mock_ak}):
+            result = quote_a("510300")
+        assert result["name"] == "沪深300ETF"
+        assert result["price"] == 4.05
+        assert result["is_etf"] is True
+
+    @patch("tools.stock_data._quote_pytdx")
+    @patch("tools.stock_data._quote_efinance")
+    @patch("tools.stock_data._quote_tushare")
+    @patch("tools.stock_data._quote_akshare")
+    def test_stock_quote_has_no_etf_source(self, mock_ak, mock_ts, mock_ef, mock_ptdx):
+        """Non-ETF A-share quote chain unchanged: no fund spot attempt."""
+        mock_ak.return_value = {"price": 1800}
+        result = quote_a("600519")
+        assert result == {"price": 1800}
+        mock_ak.assert_called_once()

--- a/tests/test_trading_calendar.py
+++ b/tests/test_trading_calendar.py
@@ -1,5 +1,7 @@
 from datetime import datetime
 
+import pytest
+
 from tools.trading_calendar import _is_weekend
 
 
@@ -18,3 +20,32 @@ class TestIsWeekend:
 
     def test_wednesday(self):
         assert _is_weekend(datetime(2024, 7, 10)) is False  # Wednesday
+
+
+from tools.trading_calendar import is_trading_day  # noqa: E402
+
+
+class TestNewMarkets:
+    def test_jp_weekend_not_trading(self):
+        r = is_trading_day("JP", "2024-01-06")  # Saturday
+        assert r["is_trading_day"] is False
+        assert r["reason"] == "weekend"
+
+    def test_kr_weekday_is_trading(self):
+        # 2024-07-10 Wednesday, no JP/KR/TW holiday — true via calendar lib or fallback
+        r = is_trading_day("KR", "2024-07-10")
+        assert r["is_trading_day"] is True
+
+    def test_tw_weekday_is_trading(self):
+        r = is_trading_day("TW", "2024-07-10")
+        assert r["is_trading_day"] is True
+
+    def test_jp_uses_exchange_calendar_when_available(self):
+        pytest.importorskip("exchange_calendars")
+        r = is_trading_day("JP", "2024-01-01")  # New Year's Day, TSE closed
+        assert r["is_trading_day"] is False
+        assert r["source"] == "exchange-calendars"
+
+    def test_unknown_market_error(self):
+        r = is_trading_day("XX", "2024-07-10")
+        assert "error" in r

--- a/tools/capabilities.py
+++ b/tools/capabilities.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """Market capability boundaries — tell agent what a given market supports.
 
-Prevents agents from calling A-share-only tools on HK/US and vice versa.
+Prevents agents from calling A-share-only tools on HK/US/JP/KR/TW and vice versa.
 """
 
 import argparse
@@ -13,21 +13,23 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 from stock_data import detect_market
 
+ALL_MARKETS = ["A", "HK", "US", "JP", "KR", "TW"]
+
 # tool_name -> {markets: [supported markets], reason: str for unsupported}
 TOOL_MATRIX = {
-    "get_kline": {"markets": ["A", "HK", "US"], "reason": None},
-    "get_quote": {"markets": ["A", "HK", "US"], "reason": None},
-    "get_news": {"markets": ["A", "HK", "US"], "reason": None},
-    "get_financials": {"markets": ["A", "HK", "US"], "reason": None},
-    "get_technical_analysis": {"markets": ["A", "HK", "US"], "reason": None},
-    "analyze_pattern": {"markets": ["A", "HK", "US"], "reason": None},
-    "get_market_indices": {"markets": ["A", "HK", "US"], "reason": None},
-    "calculate_ma": {"markets": ["A", "HK", "US"], "reason": None},
-    "get_volume_analysis": {"markets": ["A", "HK", "US"], "reason": None},
-    "detect_anomaly": {"markets": ["A", "HK", "US"], "reason": None},
-    "get_stock_info": {"markets": ["A", "HK", "US"], "reason": None},
-    "detect_market_regime": {"markets": ["A", "HK", "US"], "reason": None},
-    "get_market_review": {"markets": ["A", "HK", "US"], "reason": None},
+    "get_kline": {"markets": ALL_MARKETS, "reason": None},
+    "get_quote": {"markets": ALL_MARKETS, "reason": None},
+    "get_news": {"markets": ALL_MARKETS, "reason": None},
+    "get_financials": {"markets": ALL_MARKETS, "reason": None},
+    "get_technical_analysis": {"markets": ALL_MARKETS, "reason": None},
+    "analyze_pattern": {"markets": ALL_MARKETS, "reason": None},
+    "get_market_indices": {"markets": ALL_MARKETS, "reason": None},
+    "calculate_ma": {"markets": ALL_MARKETS, "reason": None},
+    "get_volume_analysis": {"markets": ALL_MARKETS, "reason": None},
+    "detect_anomaly": {"markets": ALL_MARKETS, "reason": None},
+    "get_stock_info": {"markets": ALL_MARKETS, "reason": None},
+    "detect_market_regime": {"markets": ["A", "HK", "US"], "reason": "index coverage is CN/HK/US only"},
+    "get_market_review": {"markets": ["A", "HK", "US"], "reason": "review data coverage is CN/HK/US only"},
     # A-share only
     "get_capital_flow": {"markets": ["A"], "reason": "A-share only (akshare data)"},
     "get_chip_distribution": {"markets": ["A"], "reason": "A-share only"},
@@ -41,14 +43,14 @@ TOOL_MATRIX = {
         "reason": "sentiment providers are US-centric; requires SENTIMENT_API_KEY",
     },
     "get_trending_sentiment": {
-        "markets": ["A", "HK", "US"],
+        "markets": ALL_MARKETS,
         "reason": None,
     },
     # search-based, market-agnostic
-    "search_stock_news": {"markets": ["A", "HK", "US"], "reason": None},
-    "search_comprehensive_intel": {"markets": ["A", "HK", "US"], "reason": None},
-    "extract_article": {"markets": ["A", "HK", "US"], "reason": None},
-    "screen_risk": {"markets": ["A", "HK", "US"], "reason": None},
+    "search_stock_news": {"markets": ALL_MARKETS, "reason": None},
+    "search_comprehensive_intel": {"markets": ALL_MARKETS, "reason": None},
+    "extract_article": {"markets": ALL_MARKETS, "reason": None},
+    "screen_risk": {"markets": ALL_MARKETS, "reason": None},
 }
 
 
@@ -81,7 +83,7 @@ def main():
     sub = parser.add_subparsers(dest="command")
     p = sub.add_parser("get")
     grp = p.add_mutually_exclusive_group(required=True)
-    grp.add_argument("--market", type=str.upper, choices=["A", "HK", "US"], help="Market code")
+    grp.add_argument("--market", type=str.upper, choices=ALL_MARKETS, help="Market code")
     grp.add_argument("--symbol", help="Stock symbol (auto-detects market)")
     args = parser.parse_args()
 

--- a/tools/diagnostics.py
+++ b/tools/diagnostics.py
@@ -19,8 +19,8 @@ PROVIDERS = {
     "tushare": ("tushare", ["TUSHARE_TOKEN"], ["A"], None),
     "efinance": ("efinance", [], ["A"], None),
     "pytdx": ("pytdx", [], ["A"], "connects to public Tencent servers"),
-    "yfinance": ("yfinance", [], ["HK", "US"], "quote may be delayed 15-20min"),
-    "finnhub": ("finnhub", ["FINNHUB_API_KEY"], ["US"], None),
+    "yfinance": ("yfinance", [], ["HK", "US", "JP", "KR", "TW"], "quote may be delayed 15-20min"),
+    "finnhub": ("finnhub", ["FINNHUB_API_KEY"], ["HK", "US"], None),
     "longbridge": (
         "longport.openapi",
         ["LONGBRIDGE_APP_KEY", "LONGBRIDGE_APP_SECRET", "LONGBRIDGE_ACCESS_TOKEN"],
@@ -68,7 +68,7 @@ def diagnose(market: str = "all") -> dict:
     market = (market or "all").upper()
     all_providers = [_check_provider(p) for p in PROVIDERS]
 
-    markets_to_report = ["A", "HK", "US"] if market == "ALL" else [market]
+    markets_to_report = ["A", "HK", "US", "JP", "KR", "TW"] if market == "ALL" else [market]
 
     result = {
         "meta": {
@@ -97,6 +97,8 @@ def diagnose(market: str = "all") -> dict:
             and not any(p["name"] == "finnhub" and p["available"] for p in providers)
         ):
             warnings.append(f"{m} quotes will be delayed (yfinance only)")
+        if m in ("JP", "KR", "TW"):
+            warnings.append(f"{m} is served by yfinance only — quotes delayed 15-20min, no failover")
 
         result["markets"].append(
             {
@@ -118,7 +120,7 @@ def main():
         "--market",
         default="ALL",
         type=str.upper,
-        choices=["A", "HK", "US", "ALL"],
+        choices=["A", "HK", "US", "JP", "KR", "TW", "ALL"],
         help="Market to diagnose (default: ALL)",
     )
     args = parser.parse_args()

--- a/tools/import_parser.py
+++ b/tools/import_parser.py
@@ -17,8 +17,14 @@ from name_resolver import resolve  # noqa: E402
 # regex patterns
 RE_A_CODE = re.compile(r"(?<!\d)(\d{6})(?!\d)")
 RE_HK_CODE = re.compile(r"(?<![A-Za-z0-9])(\d{4,5}\.HK)(?![A-Za-z0-9])", re.IGNORECASE)
+RE_ASIA_SUFFIX_CODE = re.compile(
+    r"(?<![A-Za-z0-9])(\d{4}\.T|\d{6}\.(?:KS|KQ)|\d{4}\.(?:TW|TWO))(?![A-Za-z0-9])", re.IGNORECASE
+)
 RE_US_TICKER = re.compile(r"(?<![A-Za-z0-9])([A-Z]{1,5})(?![A-Za-z0-9\.])")
 RE_CN_NAME = re.compile(r"[一-鿿][一-鿿\w]{1,7}")
+
+# suffix -> market for RE_ASIA_SUFFIX_CODE
+SUFFIX_MARKET = {"T": "JP", "KS": "KR", "KQ": "KR", "TW": "TW", "TWO": "TW"}
 
 # US ticker false-positive filter (common ALL-CAPS words that aren't tickers)
 US_STOPWORDS = {
@@ -158,9 +164,20 @@ def parse(text: str) -> dict:
             seen_symbols.add(code)
             hk_matches.append(m.group(1))
 
-    # strip HK codes so their 4-5 digit part doesn't get picked up as A-share
+    # 1b. JP/KR/TW suffixed codes (7203.T, 005930.KS, 2330.TW — digits would hit A-share regex too)
+    asia_matches: list[str] = []
+    for m in RE_ASIA_SUFFIX_CODE.finditer(text):
+        code = m.group(1).upper()
+        suffix = code.split(".", 1)[1]
+        if code not in seen_symbols:
+            items.append({"symbol": code, "market": SUFFIX_MARKET[suffix]})
+            seen_symbols.add(code)
+            asia_matches.append(m.group(1))
+
+    # strip suffixed codes so their digit part doesn't get picked up as A-share
+    # and their suffix doesn't get picked up as a US ticker
     text_after_hk = text
-    for m in hk_matches:
+    for m in hk_matches + asia_matches:
         text_after_hk = text_after_hk.replace(m, " ")
 
     # 2. A-share 6-digit codes
@@ -171,7 +188,8 @@ def parse(text: str) -> dict:
             seen_symbols.add(code)
 
     # 3. US tickers (1-5 uppercase letters), filtered against stopwords
-    for m in RE_US_TICKER.finditer(text):
+    # runs on stripped text so HK/JP/KR/TW suffixes (HK, TW, KS...) aren't misread as tickers
+    for m in RE_US_TICKER.finditer(text_after_hk):
         tick = m.group(1)
         if tick in US_STOPWORDS:
             continue

--- a/tools/search_intel.py
+++ b/tools/search_intel.py
@@ -146,6 +146,46 @@ def _bocha_search(query: str, max_results: int = 5) -> list[dict]:
         return []
 
 
+def _searxng_search(query: str, max_results: int = 5) -> list[dict]:
+    """SearXNG self-hosted metasearch — no API key, quota-free fallback.
+
+    Set SEARXNG_BASE_URLS to a comma-separated list of instance URLs,
+    e.g. "http://127.0.0.1:8080,https://searx.example.com".
+    """
+    base_urls = [u.strip().rstrip("/") for u in os.environ.get("SEARXNG_BASE_URLS", "").split(",") if u.strip()]
+    if not base_urls:
+        return []
+    try:
+        import requests
+    except ImportError:
+        return []
+    for base in base_urls:
+        try:
+            resp = requests.get(
+                f"{base}/search",
+                params={"q": query, "format": "json"},
+                headers={"Accept": "application/json"},
+                timeout=15,
+            )
+            if not resp.ok:
+                continue
+            data = resp.json()
+            results = [
+                {
+                    "title": r.get("title", ""),
+                    "url": r.get("url", ""),
+                    "snippet": (r.get("content") or "")[:200],
+                    "source": "searxng",
+                }
+                for r in data.get("results", [])
+            ]
+            if results:
+                return results
+        except Exception:
+            continue
+    return []
+
+
 def search_news(query: str, max_results: int = 10) -> dict:
     results = []
     engines_tried = []
@@ -156,6 +196,7 @@ def search_news(query: str, max_results: int = 10) -> dict:
         ("brave", _brave_search),
         ("bocha", _bocha_search),
         ("serpapi", _serpapi_search),
+        ("searxng", _searxng_search),
     ]:
         engines_tried.append(name)
         items = fn(query, max_results)
@@ -170,7 +211,10 @@ def search_news(query: str, max_results: int = 10) -> dict:
             "query": query,
             "results": [],
             "engines_tried": engines_tried,
-            "note": "No search engines configured. Set TAVILY_API_KEY, BRAVE_API_KEY, or SERPAPI_KEY in environment.",
+            "note": (
+                "No search engines configured. Set TAVILY_API_KEY, BRAVE_API_KEY, BOCHA_API_KEY, "
+                "SERPAPI_KEY, or SEARXNG_BASE_URLS in environment."
+            ),
         }
 
     seen_urls = set()

--- a/tools/stock_data.py
+++ b/tools/stock_data.py
@@ -11,8 +11,15 @@ from datetime import datetime, timedelta
 
 
 def detect_market(symbol: str) -> str:
-    if symbol.upper().endswith(".HK"):
+    s = symbol.upper()
+    if s.endswith(".HK"):
         return "HK"
+    if s.endswith(".T"):
+        return "JP"
+    if s.endswith((".KS", ".KQ")):
+        return "KR"
+    if s.endswith((".TW", ".TWO")):
+        return "TW"
     if re.match(r"^\d{6}$", symbol):
         return "A"
     return "US"
@@ -77,10 +84,10 @@ def _failover(sources: list, label: str = ""):
     return None
 
 
-def _akshare_retry(fn, *args, retries=2, delay=1):
+def _akshare_retry(fn, *args, retries=2, delay=1, **kwargs):
     for attempt in range(retries + 1):
         try:
-            return fn(*args)
+            return fn(*args, **kwargs)
         except Exception:
             if attempt == retries:
                 raise
@@ -247,8 +254,10 @@ def _kline_akshare(symbol: str, period: str, count: int) -> list:
     end = datetime.now()
     start = end - timedelta(days=count * 7 if period == "weekly" else count * 31 if period == "monthly" else count * 2)
 
+    # ETFs (51/52/56/58/15/16/18xxxx) are not covered by stock_zh_a_hist
+    hist_fn = ak.fund_etf_hist_em if normalize_stock_code(symbol)["is_etf"] else ak.stock_zh_a_hist
     df = _akshare_retry(
-        ak.stock_zh_a_hist,
+        hist_fn,
         symbol=symbol,
         period=period_map.get(period, "daily"),
         start_date=start.strftime("%Y%m%d"),
@@ -664,13 +673,15 @@ def _quote_alphavantage(symbol: str) -> dict:
 
 
 def kline_yf(symbol: str, period: str, count: int) -> list:
-    """HK/US kline with failover: yfinance → finnhub → longbridge → alphavantage (US only)."""
-    sources = [
-        ("yfinance", lambda: _kline_yfinance(symbol, period, count)),
-        ("finnhub", lambda: _kline_finnhub(symbol, period, count)),
-        ("longbridge", lambda: _kline_longbridge(symbol, period, count)),
-    ]
-    if detect_market(symbol) == "US":
+    """HK/US/JP/KR/TW kline. Failover: yfinance → finnhub/longbridge (HK/US) → alphavantage (US only)."""
+    market = detect_market(symbol)
+    sources = [("yfinance", lambda: _kline_yfinance(symbol, period, count))]
+    if market in ("HK", "US"):
+        sources += [
+            ("finnhub", lambda: _kline_finnhub(symbol, period, count)),
+            ("longbridge", lambda: _kline_longbridge(symbol, period, count)),
+        ]
+    if market == "US":
         sources.append(("alphavantage", lambda: _kline_alphavantage(symbol, period, count)))
     return _failover(sources, label=f"kline:{symbol}")
 
@@ -691,15 +702,46 @@ def cmd_kline(args):
 
 
 def quote_a(symbol: str) -> dict:
-    """A-share quote with failover: akshare → tushare → efinance → pytdx."""
-    return _failover(
-        [
-            ("akshare", lambda: _quote_akshare(symbol)),
-            ("tushare", lambda: _quote_tushare(symbol)),
-            ("efinance", lambda: _quote_efinance(symbol)),
-            ("pytdx", lambda: _quote_pytdx(symbol)),
-        ],
-        label=f"quote_a:{symbol}",
+    """A-share quote with failover: akshare → tushare → efinance → pytdx. ETFs try fund spot first."""
+    sources = []
+    if normalize_stock_code(symbol)["is_etf"]:
+        sources.append(("akshare_etf", lambda: _quote_akshare_etf(symbol)))
+    sources += [
+        ("akshare", lambda: _quote_akshare(symbol)),
+        ("tushare", lambda: _quote_tushare(symbol)),
+        ("efinance", lambda: _quote_efinance(symbol)),
+        ("pytdx", lambda: _quote_pytdx(symbol)),
+    ]
+    return _failover(sources, label=f"quote_a:{symbol}")
+
+
+def _quote_akshare_etf(symbol: str) -> dict:
+    """A-share ETF realtime quote via akshare fund_etf_spot_em."""
+    import akshare as ak
+
+    df = _akshare_retry(ak.fund_etf_spot_em)
+    row = df[df["代码"] == symbol]
+    if row.empty:
+        raise ValueError(f"ETF {symbol} not found in akshare fund spot")
+    r = row.iloc[0]
+    return _clean_row(
+        {
+            "symbol": symbol,
+            "name": r.get("名称"),
+            "price": r.get("最新价"),
+            "change": r.get("涨跌额"),
+            "change_pct": r.get("涨跌幅"),
+            "volume": r.get("成交量"),
+            "turnover": r.get("成交额"),
+            "high": r.get("最高价"),
+            "low": r.get("最低价"),
+            "open": r.get("开盘价"),
+            "prev_close": r.get("昨收"),
+            "market_cap": r.get("总市值"),
+            "turnover_rate": r.get("换手率"),
+            "volume_ratio": r.get("量比"),
+            "is_etf": True,
+        }
     )
 
 
@@ -788,13 +830,15 @@ def _quote_finnhub(symbol: str) -> dict:
 
 
 def quote_yf(symbol: str) -> dict:
-    """HK/US quote with failover: yfinance → finnhub → longbridge → alphavantage (US only)."""
-    sources = [
-        ("yfinance", lambda: _quote_yfinance(symbol)),
-        ("finnhub", lambda: _quote_finnhub(symbol)),
-        ("longbridge", lambda: _quote_longbridge(symbol)),
-    ]
-    if detect_market(symbol) == "US":
+    """HK/US/JP/KR/TW quote. Failover: yfinance → finnhub/longbridge (HK/US) → alphavantage (US only)."""
+    market = detect_market(symbol)
+    sources = [("yfinance", lambda: _quote_yfinance(symbol))]
+    if market in ("HK", "US"):
+        sources += [
+            ("finnhub", lambda: _quote_finnhub(symbol)),
+            ("longbridge", lambda: _quote_longbridge(symbol)),
+        ]
+    if market == "US":
         sources.append(("alphavantage", lambda: _quote_alphavantage(symbol)))
     return _failover(sources, label=f"quote:{symbol}")
 
@@ -1212,13 +1256,19 @@ def cmd_market_indices(args):
                     )
                 )
             return results
-        elif region in ("hk", "us"):
+        elif region in ("hk", "us", "jp", "kr", "tw"):
             import yfinance as yf
 
             if region == "hk":
                 symbols = {"^HSI": "恒生指数", "^HSCE": "恒生国企指数", "^HSTECH": "恒生科技指数"}
-            else:
+            elif region == "us":
                 symbols = {"^DJI": "道琼斯", "^IXIC": "纳斯达克", "^GSPC": "标普500", "^RUT": "罗素2000"}
+            elif region == "jp":
+                symbols = {"^N225": "日经225", "^TOPX": "东证指数"}
+            elif region == "kr":
+                symbols = {"^KS11": "韩国KOSPI", "^KQ11": "韩国KOSDAQ"}
+            else:
+                symbols = {"^TWII": "台湾加权指数"}
             results = []
             for sym, name in symbols.items():
                 try:
@@ -1610,7 +1660,7 @@ def main():
     p_snap.add_argument("--market", default="A", choices=["A", "HK", "US"])
 
     p_idx = sub.add_parser("market_indices")
-    p_idx.add_argument("--region", default="cn", choices=["cn", "hk", "us"])
+    p_idx.add_argument("--region", default="cn", choices=["cn", "hk", "us", "jp", "kr", "tw"])
 
     p_sec = sub.add_parser("sector_rankings")
     p_sec.add_argument("--top", type=int, default=10)

--- a/tools/trading_calendar.py
+++ b/tools/trading_calendar.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Trading calendar — determine trading days for CN/HK/US markets."""
+"""Trading calendar — determine trading days for CN/HK/US/JP/KR/TW markets."""
 
 import argparse
 import json
@@ -119,6 +119,26 @@ def is_trading_day(market: str, date_str: str = None) -> dict:
             return {"date": date_str, "market": market, "is_trading_day": False, "reason": "US_holiday"}
         return {"date": date_str, "market": market, "is_trading_day": True, "reason": "trading_day"}
 
+    elif market in ("JP", "KR", "TW"):
+        exchange_map = {"JP": "XTKS", "KR": "XKRX", "TW": "XTAI"}
+        try:
+            is_td = _is_exchange_trading_day(exchange_map[market], date_str)
+            return {
+                "date": date_str,
+                "market": market,
+                "is_trading_day": is_td,
+                "reason": "trading_day" if is_td else "holiday",
+                "source": "exchange-calendars",
+            }
+        except Exception:
+            pass
+        return {
+            "date": date_str,
+            "market": market,
+            "is_trading_day": True,
+            "reason": "assumed_trading_day (calendar unavailable)",
+        }
+
     return {"date": date_str, "market": market, "error": f"Unknown market: {market}"}
 
 
@@ -171,16 +191,16 @@ def main():
     sub = parser.add_subparsers(dest="command")
 
     p_check = sub.add_parser("check")
-    p_check.add_argument("market", choices=["CN", "HK", "US", "cn", "hk", "us"])
+    p_check.add_argument("market", choices=["CN", "HK", "US", "JP", "KR", "TW", "cn", "hk", "us", "jp", "kr", "tw"])
     p_check.add_argument("--date", default=None, help="Date in YYYY-MM-DD format")
 
     p_next = sub.add_parser("next")
-    p_next.add_argument("market", choices=["CN", "HK", "US", "cn", "hk", "us"])
+    p_next.add_argument("market", choices=["CN", "HK", "US", "JP", "KR", "TW", "cn", "hk", "us", "jp", "kr", "tw"])
     p_next.add_argument("--count", type=int, default=5)
     p_next.add_argument("--date", default=None)
 
     p_prev = sub.add_parser("prev")
-    p_prev.add_argument("market", choices=["CN", "HK", "US", "cn", "hk", "us"])
+    p_prev.add_argument("market", choices=["CN", "HK", "US", "JP", "KR", "TW", "cn", "hk", "us", "jp", "kr", "tw"])
     p_prev.add_argument("--count", type=int, default=5)
     p_prev.add_argument("--date", default=None)
 

--- a/typings/pi-agent/index.d.ts
+++ b/typings/pi-agent/index.d.ts
@@ -1,20 +1,44 @@
 declare module "pi-agent" {
+  // Mirrors the real @earendil-works/pi-coding-agent extension API (v0.83+).
+  interface TextContent {
+    type: "text";
+    text: string;
+  }
+
+  interface AgentToolResult {
+    content: TextContent[];
+    details: Record<string, unknown>;
+  }
+
   interface ToolDefinition {
     name: string;
     description: string;
     parameters: Record<string, unknown>;
-    execute(args: Record<string, unknown>): Promise<string>;
+    execute(
+      toolCallId: string,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      params: any,
+      ...rest: unknown[]
+    ): Promise<AgentToolResult>;
   }
 
   interface ExecResult {
     stdout: string;
     stderr: string;
-    exitCode: number;
+    code: number;
+    killed: boolean;
+  }
+
+  interface ResourcesDiscoverResult {
+    skillPaths?: string[];
+    promptPaths?: string[];
+    themePaths?: string[];
   }
 
   interface ExtensionAPI {
-    exec(command: string): Promise<ExecResult>;
+    exec(command: string, args?: string[], options?: { timeout?: number }): Promise<ExecResult>;
     registerTool(tool: ToolDefinition): void;
-    on(event: string, handler: (...args: unknown[]) => unknown): void;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    on(event: string, handler: (...args: any[]) => any): void;
   }
 }


### PR DESCRIPTION
## Summary

Adds a **blocking** `e2e-host` CI job (matrix: `pi` / `openclaw` / `hermes`) that installs the plugin into the **real** host runtime and drives one QA turn through the host's own agent loop — the layer the user asked for after reviewing #4. Per request, this check gates the pipeline; the smoke retries the QA once internally to absorb LLM nondeterminism.

Stacked on #4 (shares the `pi/index.ts` diff surface); merge #4 first.

## What the smoke does (per host)

1. **Real install from the PR code** — `pi install <repo> -l` / `openclaw plugins install <packed tarball>` (replicating the publish staging + new dist build) / `pip install .` into the same env as `hermes-agent`
2. **Load assertion** — package visible to the host, compiled entry + payload present
3. **QA assertion** — fixed question ("use `get_quote` to check AAPL's latest price"), asserting both the **tool-call trace** (NDJSON event / session transcript / `api_calls >= 2` in the usage report) and a **numeric final answer**. US stock on purpose: yfinance works from GitHub IPs, unlike the eastmoney endpoints that keep `e2e-network` red on `main`.

## Runtime bugs the real-host spike exposed (all fixed here)

Previous layers (stubbed registration, subprocess round-trip, LLM loop over mocked host APIs) structurally could not catch these:

- **`pi/index.ts` was fully broken against real Pi 0.83** — all 39 tools returned *empty content* to the model:
  - `execute()` destructured the first arg as params, but the real signature is `execute(toolCallId, params, …)`
  - returned a bare string; real Pi expects `AgentToolResult { content: [{type:"text",text}], details }`
  - `pi.exec(singleString)` — the real `exec(command, args[])` spawns with `shell:false`, so the command never even ran
- **Hermes entry point silently never loaded** — `stock-analysis = "hermes:register"` makes `ep.load()` return the function; the loader then looks for `register` *on that function*, logs "no register() function", and registers zero tools. Fixed to `"hermes"`.
- **OpenClaw packaged installs were unloadable** — package installs reject TS entries; added an esbuild step (`npm run build:openclaw` → `dist/index.js`, typebox bundled, `openclaw/*` external), shipped `dist/` in `files`, added `openclaw/.npmignore` (root `.gitignore`'s `dist/` was excluding it from the tarball), and wired the build into `publish.yml`.

Docs corrected to match reality (Pi execute/exec contract, module-style Hermes entry point); `typings/pi-agent` regenerated to the real API; test doubles updated accordingly.

## Verification

- Local real-host runs (real LLM): all three smokes pass, each returning the live AAPL price — pi `toolCalled=true`, openclaw `toolCalled=true`, hermes `apiCalls=2`
- 444 pytest + ruff + tsc + all TS integration/e2e suites green
- The new `e2e-host` job itself will run on this PR (DeepSeek secret required)

## Notes

- `e2e-network` remains red on this branch as on `main` (upstream eastmoney throttling, pre-existing).
- One hardening follow-up worth doing later: the `parse_stock_list` LLM e2e is prompt-compliance-flaky (model sometimes passes company names instead of tickers); consider pinning the tool input in that test's prompt.
