### PR TITLE
fix(hosts): correct Windows venv python path + fallback across pi/openclaw/hermes

### DIFF
--- a/hermes/tools.py
+++ b/hermes/tools.py
@@ -9,12 +9,15 @@ TOOLS_DIR = PROJECT_ROOT / "tools"
 
 
 def _find_python() -> str:
-    venv_python = PROJECT_ROOT / ".venv" / "bin" / "python3"
+    # Windows venvs ship Scripts/python.exe (there is no python3); POSIX venvs ship bin/python3.
     if sys.platform == "win32":
-        venv_python = PROJECT_ROOT / ".venv" / "Scripts" / "python3.exe"
+        venv_python = PROJECT_ROOT / ".venv" / "Scripts" / "python.exe"
+    else:
+        venv_python = PROJECT_ROOT / ".venv" / "bin" / "python3"
     if venv_python.exists():
         return str(venv_python)
-    return "python3"
+    # On Windows "python3" is usually the Microsoft Store stub — prefer "python".
+    return "python" if sys.platform == "win32" else "python3"
 
 
 def _run(script: str, args: str) -> str:

--- a/openclaw/index.ts
+++ b/openclaw/index.ts
@@ -27,15 +27,18 @@ const toolsDir = existsSync(join(here, "tools"))
   : join(here, "..", "tools");
 const repoRoot = dirname(toolsDir);
 const isWin = process.platform === "win32";
-const venvPython = join(repoRoot, ".venv", isWin ? "Scripts" : "bin", "python3");
+// Windows venvs ship Scripts/python.exe (there is no python3); POSIX venvs ship bin/python3.
+const venvBin = join(".venv", isWin ? "Scripts" : "bin", isWin ? "python.exe" : "python3");
+const venvPython = join(repoRoot, venvBin);
 // Staged-payload layout (openclaw/tools present in a dev checkout): the venv
 // still lives at the repo root one level up.
-const parentVenvPython = join(repoRoot, "..", ".venv", isWin ? "Scripts" : "bin", "python3");
+const parentVenvPython = join(repoRoot, "..", venvBin);
 
 function pythonBin(): string {
   if (existsSync(venvPython)) return venvPython;
   if (existsSync(parentVenvPython)) return parentVenvPython;
-  return "python3";
+  // On Windows "python3" is usually the Microsoft Store stub — prefer "python".
+  return isWin ? "python" : "python3";
 }
 
 async function runPy(script: string, args: string[]): Promise<string> {

--- a/pi/index.ts
+++ b/pi/index.ts
@@ -1,11 +1,20 @@
 import type { ExtensionAPI } from "pi-agent";
 import { existsSync } from "fs";
+import { fileURLToPath } from "url";
 
 export default (pi: ExtensionAPI) => {
-  const toolsDir = `${__dirname}/../tools`;
+  // Resolve the plugin root robustly: __dirname under jiti/CJS-style loaders,
+  // else import.meta.url under native ESM (where __dirname is undefined).
+  const baseDir =
+    typeof __dirname !== "undefined"
+      ? `${__dirname}/..`
+      : fileURLToPath(new URL("..", import.meta.url));
+  const toolsDir = `${baseDir}/tools`;
   const isWin = process.platform === "win32";
-  const venvPython = `${__dirname}/../.venv/${isWin ? "Scripts" : "bin"}/python3`;
-  const python = existsSync(venvPython) ? venvPython : "python3";
+  // Windows venvs ship Scripts/python.exe (there is no python3); POSIX venvs ship bin/python3.
+  const venvPython = `${baseDir}/.venv/${isWin ? "Scripts/python.exe" : "bin/python3"}`;
+  // Fallback: on Windows "python3" is usually the Microsoft Store stub — prefer "python".
+  const python = existsSync(venvPython) ? venvPython : isWin ? "python" : "python3";
   const py = (script: string, args: string[]) =>
     pi.exec(python, [`${toolsDir}/${script}`, ...args]);
   const asText = (text: string) => ({
@@ -1108,26 +1117,26 @@ export default (pi: ExtensionAPI) => {
 
   pi.on("resources_discover", () => ({
     skillPaths: [
-      `${__dirname}/../skills/stock-analysis/SKILL.md`,
-      `${__dirname}/../skills/stock-screener/SKILL.md`,
-      `${__dirname}/../skills/strategy-backtest/SKILL.md`,
-      `${__dirname}/../skills/bull-trend/SKILL.md`,
-      `${__dirname}/../skills/shrink-pullback/SKILL.md`,
-      `${__dirname}/../skills/ma-crossover/SKILL.md`,
-      `${__dirname}/../skills/volume-breakout/SKILL.md`,
-      `${__dirname}/../skills/bottom-volume/SKILL.md`,
-      `${__dirname}/../skills/dragon-head/SKILL.md`,
-      `${__dirname}/../skills/chan-theory/SKILL.md`,
-      `${__dirname}/../skills/wave-theory/SKILL.md`,
-      `${__dirname}/../skills/box-oscillation/SKILL.md`,
-      `${__dirname}/../skills/emotion-cycle/SKILL.md`,
-      `${__dirname}/../skills/one-yang-three-yin/SKILL.md`,
-      `${__dirname}/../skills/wisburg-research/SKILL.md`,
-      `${__dirname}/../skills/market-review/SKILL.md`,
-      `${__dirname}/../skills/event-driven/SKILL.md`,
-      `${__dirname}/../skills/expectation-repricing/SKILL.md`,
-      `${__dirname}/../skills/growth-quality/SKILL.md`,
-      `${__dirname}/../skills/hot-theme/SKILL.md`,
+      `${baseDir}/skills/stock-analysis/SKILL.md`,
+      `${baseDir}/skills/stock-screener/SKILL.md`,
+      `${baseDir}/skills/strategy-backtest/SKILL.md`,
+      `${baseDir}/skills/bull-trend/SKILL.md`,
+      `${baseDir}/skills/shrink-pullback/SKILL.md`,
+      `${baseDir}/skills/ma-crossover/SKILL.md`,
+      `${baseDir}/skills/volume-breakout/SKILL.md`,
+      `${baseDir}/skills/bottom-volume/SKILL.md`,
+      `${baseDir}/skills/dragon-head/SKILL.md`,
+      `${baseDir}/skills/chan-theory/SKILL.md`,
+      `${baseDir}/skills/wave-theory/SKILL.md`,
+      `${baseDir}/skills/box-oscillation/SKILL.md`,
+      `${baseDir}/skills/emotion-cycle/SKILL.md`,
+      `${baseDir}/skills/one-yang-three-yin/SKILL.md`,
+      `${baseDir}/skills/wisburg-research/SKILL.md`,
+      `${baseDir}/skills/market-review/SKILL.md`,
+      `${baseDir}/skills/event-driven/SKILL.md`,
+      `${baseDir}/skills/expectation-repricing/SKILL.md`,
+      `${baseDir}/skills/growth-quality/SKILL.md`,
+      `${baseDir}/skills/hot-theme/SKILL.md`,
     ],
   }));
 };


### PR DESCRIPTION
## 问题

跨平台 Windows venv Python 路径 bug —— 三个宿主入口全部中招。

Windows 的 venv 只有 `Scripts/python.exe`(**没有** `python3`/`python3.exe`),而裸 `python3` 命令在 Windows 上通常是 **Microsoft Store 假 stub**(执行后打开商店或直接失败)。三个宿主都把 `python3` 硬编进了 venv 路径和回退命令，导致 Windows 上:

1. 永远找不到 venv 解释器 → 回退
2. 回退到 `python3` → 命中 Store stub → 拿不到数据/报错

> 注:issue #2 里说"hermes/openclaw 不受影响"并不成立 —— 三处是同一个根因。

## 改动

| 文件 | 修复 |
|---|---|
| `pi/index.ts` | venv 用 `Scripts/python.exe`(win32)/`bin/python3`(POSIX);回退 `python`(win32)/`python3`(POSIX)。另:`baseDir` 改为 `__dirname`(jiti/CJS)优先、`import.meta.url`(原生 ESM)兜底,`resources_discover` 的 20 个 skill 路径一并换用 |
| `openclaw/index.ts` | 同 venv exe + 回退修复(`pythonBin()`) |
| `hermes/tools.py` | 同 venv exe(原找 `Scripts/python3.exe`)+ 回退修复(`_find_python()`) |

`tools/gather.py` 未动:它本就连回退到 `sys.executable`,Windows 上不会崩,且有测试 pin 该行为。

POSIX 路径**完全不变**(`.venv/bin/python3` 命中逻辑一致),只修 Windows 分支,零回归风险。

## 与 issue #2 的关系

- **Bug 1**(`pi.exec` 单字符串崩溃):已在 **0.1.6** 修复(`pi.exec(python, [...])`),报告者升级即可。
- **Bug 2**(Windows venv 路径):**本 PR 修复** —— 这是 #2 里唯一仍成立的真问题。
- **Bug 3**(`__dirname` undefined):实为误诊(jiti 下 `__dirname` 有效,集成测试也依赖它),但本 PR 顺带加了 `import.meta.url` 兜底彻底消除隐患。

## 验证(本地全绿)

- `tsc --noEmit` ✅
- `ruff check` + `ruff format --check`(tools/ skills/ tests/ hermes/)✅
- `pytest` 452 passed(非 network/llm)✅
- hermes / pi / openclaw 集成注册测试 ✅
- host↔python 真实子进程 e2e(pi / openclaw / pytest round-trip)✅ —— pi 正确解析到 `.venv/bin/python3`

Closes #2
