### PR TITLE
ci: add cross-platform (linux/macos/windows) host↔python compat job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,12 +115,13 @@ jobs:
         with:
           node-version: "20"
 
-      # requirements-dev.txt gives system python pytest (for the hermes test).
-      # npm install runs the postinstall, which builds .venv and installs the
-      # tools' full requirements into it — that .venv python is what the
-      # host↔python round-trips spawn. Heavy deps are only installed once, there.
+      # tests/conftest.py imports numpy/pandas at module load, so any pytest run
+      # needs the tools' runtime deps in system python. npm install's postinstall
+      # separately builds .venv (full requirements) — that's the python the
+      # host↔python round-trips spawn.
       - name: Install dependencies
         run: |
+          pip install -r tools/requirements.txt
           pip install -r requirements-dev.txt
           npm install
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,6 +93,55 @@ jobs:
       - name: E2E — OpenClaw host real subprocess
         run: npx tsx tests/e2e/test_openclaw_e2e.ts
 
+  compat:
+    # Cross-platform host↔python integration on the free runners. This is the
+    # regression surface for OS-specific path bugs like #2 (Windows venv python
+    # location, __dirname/baseDir resolution) that the ubuntu-only jobs above
+    # structurally cannot see. Deterministic by design: no LLM, no secrets, and
+    # the 4 round-trip tools are the non-network set (see tests/e2e/*.ts).
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      # requirements-dev.txt gives system python pytest (for the hermes test).
+      # npm install runs the postinstall, which builds .venv and installs the
+      # tools' full requirements into it — that .venv python is what the
+      # host↔python round-trips spawn. Heavy deps are only installed once, there.
+      - name: Install dependencies
+        run: |
+          pip install -r requirements-dev.txt
+          npm install
+
+      - name: TypeScript type check
+        run: npx tsc --noEmit
+
+      - name: Pi extension registration (jiti load + skill paths)
+        run: npx tsx tests/test_pi_integration.ts
+
+      - name: OpenClaw plugin registration
+        run: npx tsx tests/test_openclaw_integration.ts
+
+      - name: Hermes plugin registration
+        run: pytest tests/test_hermes_integration.py -v
+
+      - name: Pi host real subprocess round-trip
+        run: npx tsx tests/e2e/test_pi_e2e.ts
+
+      - name: OpenClaw host real subprocess round-trip
+        run: npx tsx tests/e2e/test_openclaw_e2e.ts
+
   e2e-llm:
     # Real DeepSeek call. Only runs when DEEPSEEK_API_KEY secret is present
     # (skipped on forks to prevent secret exposure).

--- a/hermes/tools.py
+++ b/hermes/tools.py
@@ -24,7 +24,7 @@ def _run(script: str, args: str) -> str:
     python = _find_python()
     cmd = f"{python} {TOOLS_DIR / script} {args}"
     try:
-        result = subprocess.run(cmd, shell=True, capture_output=True, text=True, timeout=120)
+        result = subprocess.run(cmd, shell=True, capture_output=True, text=True, encoding="utf-8", timeout=120)
     except subprocess.TimeoutExpired:
         return json.dumps({"error": "Command timed out after 120s"})
     except Exception as e:

--- a/scripts/setup-python.mjs
+++ b/scripts/setup-python.mjs
@@ -3,15 +3,15 @@ import { execSync } from "node:child_process";
 import { existsSync } from "node:fs";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
+import { venvPythonPath } from "./venv-python.mjs";
 
 // fileURLToPath (not URL.pathname) — the latter yields a bogus "/C:/..." path
 // on Windows, which would put the venv in the wrong place or fail outright.
 const pkgDir = fileURLToPath(new URL("..", import.meta.url));
-const isWin = process.platform === "win32";
 const venvDir = join(pkgDir, ".venv");
 // Drive pip through the venv's own python (`-m pip`) instead of a pip/pip.exe
-// shim — resolves correctly on both POSIX (bin/python) and Windows (Scripts/python.exe).
-const venvPython = join(venvDir, isWin ? "Scripts" : "bin", isWin ? "python.exe" : "python");
+// shim — resolves correctly on both POSIX (bin/python3) and Windows (Scripts/python.exe).
+const venvPython = venvPythonPath(pkgDir);
 const requirements = join(pkgDir, "tools", "requirements.txt");
 
 function run(cmd) {

--- a/scripts/setup-python.mjs
+++ b/scripts/setup-python.mjs
@@ -2,11 +2,16 @@
 import { execSync } from "node:child_process";
 import { existsSync } from "node:fs";
 import { join } from "node:path";
+import { fileURLToPath } from "node:url";
 
-const pkgDir = new URL("..", import.meta.url).pathname.replace(/\/$/, "");
+// fileURLToPath (not URL.pathname) — the latter yields a bogus "/C:/..." path
+// on Windows, which would put the venv in the wrong place or fail outright.
+const pkgDir = fileURLToPath(new URL("..", import.meta.url));
 const isWin = process.platform === "win32";
 const venvDir = join(pkgDir, ".venv");
-const pip = join(venvDir, isWin ? "Scripts" : "bin", "pip");
+// Drive pip through the venv's own python (`-m pip`) instead of a pip/pip.exe
+// shim — resolves correctly on both POSIX (bin/python) and Windows (Scripts/python.exe).
+const venvPython = join(venvDir, isWin ? "Scripts" : "bin", isWin ? "python.exe" : "python");
 const requirements = join(pkgDir, "tools", "requirements.txt");
 
 function run(cmd) {
@@ -41,12 +46,12 @@ try {
   }
 
   if (existsSync(requirements)) {
-    run(`"${pip}" install -q -r "${requirements}"`);
+    run(`"${venvPython}" -m pip install -q -r "${requirements}"`);
   }
 } catch (err) {
   console.warn(
     `\n[pi-stock-analysis] Python setup failed: ${err.message}\n` +
-    "You can manually run: python3 -m venv .venv && .venv/bin/pip install -r tools/requirements.txt\n"
+    "You can manually create the venv and install tools/requirements.txt with your platform's python.\n"
   );
   process.exit(0);
 }

--- a/scripts/venv-python.mjs
+++ b/scripts/venv-python.mjs
@@ -1,0 +1,20 @@
+// Canonical venv-python resolution, shared by the postinstall script and the
+// e2e harnesses. Kept in one place so the Windows/POSIX shape can't drift
+// (previously each site hardcoded its own Scripts/bin + python.exe/python3).
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+
+const isWin = process.platform === "win32";
+
+// Windows venvs ship Scripts/python.exe (there is no python3); POSIX venvs ship bin/python3.
+export function venvPythonPath(rootDir) {
+  return join(rootDir, ".venv", isWin ? "Scripts" : "bin", isWin ? "python.exe" : "python3");
+}
+
+// Interpreter to actually invoke: the venv python when present, else the
+// platform fallback — "python" on Windows, where a bare "python3" is usually
+// the Microsoft Store stub.
+export function resolvePython(rootDir) {
+  const venvPython = venvPythonPath(rootDir);
+  return existsSync(venvPython) ? venvPython : isWin ? "python" : "python3";
+}

--- a/skills/bottom-volume/scripts/gather.py
+++ b/skills/bottom-volume/scripts/gather.py
@@ -5,11 +5,18 @@ import subprocess
 import sys
 from pathlib import Path
 
+# Windows defaults stdio to a legacy code page (cp1252); force UTF-8 so the
+# child's Chinese output both decodes and re-prints here without crashing.
+for _s in (sys.stdout, sys.stderr):
+    if hasattr(_s, "reconfigure"):
+        _s.reconfigure(encoding="utf-8")
+
 tools = Path(__file__).resolve().parents[2] / "tools"
 result = subprocess.run(
     [sys.executable, str(tools / "gather.py"), "technical", sys.argv[1], "--kline-count", "120"],
     capture_output=True,
     text=True,
+    encoding="utf-8",
 )
 sys.stdout.write(result.stdout)
 sys.exit(result.returncode)

--- a/skills/box-oscillation/scripts/gather.py
+++ b/skills/box-oscillation/scripts/gather.py
@@ -5,11 +5,18 @@ import subprocess
 import sys
 from pathlib import Path
 
+# Windows defaults stdio to a legacy code page (cp1252); force UTF-8 so the
+# child's Chinese output both decodes and re-prints here without crashing.
+for _s in (sys.stdout, sys.stderr):
+    if hasattr(_s, "reconfigure"):
+        _s.reconfigure(encoding="utf-8")
+
 tools = Path(__file__).resolve().parents[2] / "tools"
 result = subprocess.run(
     [sys.executable, str(tools / "gather.py"), "technical", sys.argv[1], "--kline-count", "90"],
     capture_output=True,
     text=True,
+    encoding="utf-8",
 )
 sys.stdout.write(result.stdout)
 sys.exit(result.returncode)

--- a/skills/bull-trend/scripts/gather.py
+++ b/skills/bull-trend/scripts/gather.py
@@ -5,11 +5,18 @@ import subprocess
 import sys
 from pathlib import Path
 
+# Windows defaults stdio to a legacy code page (cp1252); force UTF-8 so the
+# child's Chinese output both decodes and re-prints here without crashing.
+for _s in (sys.stdout, sys.stderr):
+    if hasattr(_s, "reconfigure"):
+        _s.reconfigure(encoding="utf-8")
+
 tools = Path(__file__).resolve().parents[2] / "tools"
 result = subprocess.run(
     [sys.executable, str(tools / "gather.py"), "technical", sys.argv[1], "--kline-count", "120"],
     capture_output=True,
     text=True,
+    encoding="utf-8",
 )
 sys.stdout.write(result.stdout)
 sys.exit(result.returncode)

--- a/skills/chan-theory/scripts/gather.py
+++ b/skills/chan-theory/scripts/gather.py
@@ -5,11 +5,18 @@ import subprocess
 import sys
 from pathlib import Path
 
+# Windows defaults stdio to a legacy code page (cp1252); force UTF-8 so the
+# child's Chinese output both decodes and re-prints here without crashing.
+for _s in (sys.stdout, sys.stderr):
+    if hasattr(_s, "reconfigure"):
+        _s.reconfigure(encoding="utf-8")
+
 tools = Path(__file__).resolve().parents[2] / "tools"
 result = subprocess.run(
     [sys.executable, str(tools / "gather.py"), "technical", sys.argv[1], "--kline-count", "120"],
     capture_output=True,
     text=True,
+    encoding="utf-8",
 )
 sys.stdout.write(result.stdout)
 sys.exit(result.returncode)

--- a/skills/dragon-head/scripts/gather.py
+++ b/skills/dragon-head/scripts/gather.py
@@ -5,11 +5,18 @@ import subprocess
 import sys
 from pathlib import Path
 
+# Windows defaults stdio to a legacy code page (cp1252); force UTF-8 so the
+# child's Chinese output both decodes and re-prints here without crashing.
+for _s in (sys.stdout, sys.stderr):
+    if hasattr(_s, "reconfigure"):
+        _s.reconfigure(encoding="utf-8")
+
 tools = Path(__file__).resolve().parents[2] / "tools"
 result = subprocess.run(
     [sys.executable, str(tools / "gather.py"), "technical", sys.argv[1], "--kline-count", "30", "--with-quote"],
     capture_output=True,
     text=True,
+    encoding="utf-8",
 )
 sys.stdout.write(result.stdout)
 sys.exit(result.returncode)

--- a/skills/emotion-cycle/scripts/gather.py
+++ b/skills/emotion-cycle/scripts/gather.py
@@ -5,11 +5,18 @@ import subprocess
 import sys
 from pathlib import Path
 
+# Windows defaults stdio to a legacy code page (cp1252); force UTF-8 so the
+# child's Chinese output both decodes and re-prints here without crashing.
+for _s in (sys.stdout, sys.stderr):
+    if hasattr(_s, "reconfigure"):
+        _s.reconfigure(encoding="utf-8")
+
 tools = Path(__file__).resolve().parents[2] / "tools"
 result = subprocess.run(
     [sys.executable, str(tools / "gather.py"), "technical", sys.argv[1], "--kline-count", "60", "--with-quote"],
     capture_output=True,
     text=True,
+    encoding="utf-8",
 )
 sys.stdout.write(result.stdout)
 sys.exit(result.returncode)

--- a/skills/event-driven/scripts/gather.py
+++ b/skills/event-driven/scripts/gather.py
@@ -5,11 +5,18 @@ import subprocess
 import sys
 from pathlib import Path
 
+# Windows defaults stdio to a legacy code page (cp1252); force UTF-8 so the
+# child's Chinese output both decodes and re-prints here without crashing.
+for _s in (sys.stdout, sys.stderr):
+    if hasattr(_s, "reconfigure"):
+        _s.reconfigure(encoding="utf-8")
+
 tools = Path(__file__).resolve().parents[2] / "tools"
 result = subprocess.run(
     [sys.executable, str(tools / "gather.py"), "fundamental", sys.argv[1]],
     capture_output=True,
     text=True,
+    encoding="utf-8",
 )
 sys.stdout.write(result.stdout)
 sys.exit(result.returncode)

--- a/skills/expectation-repricing/scripts/gather.py
+++ b/skills/expectation-repricing/scripts/gather.py
@@ -5,11 +5,18 @@ import subprocess
 import sys
 from pathlib import Path
 
+# Windows defaults stdio to a legacy code page (cp1252); force UTF-8 so the
+# child's Chinese output both decodes and re-prints here without crashing.
+for _s in (sys.stdout, sys.stderr):
+    if hasattr(_s, "reconfigure"):
+        _s.reconfigure(encoding="utf-8")
+
 tools = Path(__file__).resolve().parents[2] / "tools"
 result = subprocess.run(
     [sys.executable, str(tools / "gather.py"), "fundamental", sys.argv[1]],
     capture_output=True,
     text=True,
+    encoding="utf-8",
 )
 sys.stdout.write(result.stdout)
 sys.exit(result.returncode)

--- a/skills/growth-quality/scripts/gather.py
+++ b/skills/growth-quality/scripts/gather.py
@@ -5,11 +5,18 @@ import subprocess
 import sys
 from pathlib import Path
 
+# Windows defaults stdio to a legacy code page (cp1252); force UTF-8 so the
+# child's Chinese output both decodes and re-prints here without crashing.
+for _s in (sys.stdout, sys.stderr):
+    if hasattr(_s, "reconfigure"):
+        _s.reconfigure(encoding="utf-8")
+
 tools = Path(__file__).resolve().parents[2] / "tools"
 result = subprocess.run(
     [sys.executable, str(tools / "gather.py"), "fundamental", sys.argv[1]],
     capture_output=True,
     text=True,
+    encoding="utf-8",
 )
 sys.stdout.write(result.stdout)
 sys.exit(result.returncode)

--- a/skills/hot-theme/scripts/gather.py
+++ b/skills/hot-theme/scripts/gather.py
@@ -5,11 +5,18 @@ import subprocess
 import sys
 from pathlib import Path
 
+# Windows defaults stdio to a legacy code page (cp1252); force UTF-8 so the
+# child's Chinese output both decodes and re-prints here without crashing.
+for _s in (sys.stdout, sys.stderr):
+    if hasattr(_s, "reconfigure"):
+        _s.reconfigure(encoding="utf-8")
+
 tools = Path(__file__).resolve().parents[2] / "tools"
 result = subprocess.run(
     [sys.executable, str(tools / "gather.py"), "fundamental", sys.argv[1]],
     capture_output=True,
     text=True,
+    encoding="utf-8",
 )
 sys.stdout.write(result.stdout)
 sys.exit(result.returncode)

--- a/skills/ma-crossover/scripts/gather.py
+++ b/skills/ma-crossover/scripts/gather.py
@@ -5,11 +5,18 @@ import subprocess
 import sys
 from pathlib import Path
 
+# Windows defaults stdio to a legacy code page (cp1252); force UTF-8 so the
+# child's Chinese output both decodes and re-prints here without crashing.
+for _s in (sys.stdout, sys.stderr):
+    if hasattr(_s, "reconfigure"):
+        _s.reconfigure(encoding="utf-8")
+
 tools = Path(__file__).resolve().parents[2] / "tools"
 result = subprocess.run(
     [sys.executable, str(tools / "gather.py"), "technical", sys.argv[1], "--kline-count", "120"],
     capture_output=True,
     text=True,
+    encoding="utf-8",
 )
 sys.stdout.write(result.stdout)
 sys.exit(result.returncode)

--- a/skills/market-review/scripts/gather.py
+++ b/skills/market-review/scripts/gather.py
@@ -5,12 +5,19 @@ import subprocess
 import sys
 from pathlib import Path
 
+# Windows defaults stdio to a legacy code page (cp1252); force UTF-8 so the
+# child's Chinese output both decodes and re-prints here without crashing.
+for _s in (sys.stdout, sys.stderr):
+    if hasattr(_s, "reconfigure"):
+        _s.reconfigure(encoding="utf-8")
+
 market = sys.argv[1] if len(sys.argv) > 1 else "A"
 tools = Path(__file__).resolve().parents[2] / "tools"
 result = subprocess.run(
     [sys.executable, str(tools / "market_review.py"), "review", "--market", market],
     capture_output=True,
     text=True,
+    encoding="utf-8",
 )
 sys.stdout.write(result.stdout)
 sys.exit(result.returncode)

--- a/skills/one-yang-three-yin/scripts/gather.py
+++ b/skills/one-yang-three-yin/scripts/gather.py
@@ -5,11 +5,18 @@ import subprocess
 import sys
 from pathlib import Path
 
+# Windows defaults stdio to a legacy code page (cp1252); force UTF-8 so the
+# child's Chinese output both decodes and re-prints here without crashing.
+for _s in (sys.stdout, sys.stderr):
+    if hasattr(_s, "reconfigure"):
+        _s.reconfigure(encoding="utf-8")
+
 tools = Path(__file__).resolve().parents[2] / "tools"
 result = subprocess.run(
     [sys.executable, str(tools / "gather.py"), "technical", sys.argv[1], "--kline-count", "30"],
     capture_output=True,
     text=True,
+    encoding="utf-8",
 )
 sys.stdout.write(result.stdout)
 sys.exit(result.returncode)

--- a/skills/shrink-pullback/scripts/gather.py
+++ b/skills/shrink-pullback/scripts/gather.py
@@ -5,11 +5,18 @@ import subprocess
 import sys
 from pathlib import Path
 
+# Windows defaults stdio to a legacy code page (cp1252); force UTF-8 so the
+# child's Chinese output both decodes and re-prints here without crashing.
+for _s in (sys.stdout, sys.stderr):
+    if hasattr(_s, "reconfigure"):
+        _s.reconfigure(encoding="utf-8")
+
 tools = Path(__file__).resolve().parents[2] / "tools"
 result = subprocess.run(
     [sys.executable, str(tools / "gather.py"), "technical", sys.argv[1], "--kline-count", "60"],
     capture_output=True,
     text=True,
+    encoding="utf-8",
 )
 sys.stdout.write(result.stdout)
 sys.exit(result.returncode)

--- a/skills/stock-analysis/scripts/gather.py
+++ b/skills/stock-analysis/scripts/gather.py
@@ -5,11 +5,18 @@ import subprocess
 import sys
 from pathlib import Path
 
+# Windows defaults stdio to a legacy code page (cp1252); force UTF-8 so the
+# child's Chinese output both decodes and re-prints here without crashing.
+for _s in (sys.stdout, sys.stderr):
+    if hasattr(_s, "reconfigure"):
+        _s.reconfigure(encoding="utf-8")
+
 tools = Path(__file__).resolve().parents[2] / "tools"
 result = subprocess.run(
     [sys.executable, str(tools / "gather.py"), "analysis", sys.argv[1]],
     capture_output=True,
     text=True,
+    encoding="utf-8",
 )
 sys.stdout.write(result.stdout)
 sys.exit(result.returncode)

--- a/skills/stock-screener/scripts/gather.py
+++ b/skills/stock-screener/scripts/gather.py
@@ -5,11 +5,18 @@ import subprocess
 import sys
 from pathlib import Path
 
+# Windows defaults stdio to a legacy code page (cp1252); force UTF-8 so the
+# child's Chinese output both decodes and re-prints here without crashing.
+for _s in (sys.stdout, sys.stderr):
+    if hasattr(_s, "reconfigure"):
+        _s.reconfigure(encoding="utf-8")
+
 tools = Path(__file__).resolve().parents[2] / "tools"
 result = subprocess.run(
     [sys.executable, str(tools / "gather.py"), "screen"] + sys.argv[1:],
     capture_output=True,
     text=True,
+    encoding="utf-8",
 )
 sys.stdout.write(result.stdout)
 sys.exit(result.returncode)

--- a/skills/strategy-backtest/scripts/gather.py
+++ b/skills/strategy-backtest/scripts/gather.py
@@ -5,11 +5,18 @@ import subprocess
 import sys
 from pathlib import Path
 
+# Windows defaults stdio to a legacy code page (cp1252); force UTF-8 so the
+# child's Chinese output both decodes and re-prints here without crashing.
+for _s in (sys.stdout, sys.stderr):
+    if hasattr(_s, "reconfigure"):
+        _s.reconfigure(encoding="utf-8")
+
 tools = Path(__file__).resolve().parents[2] / "tools"
 result = subprocess.run(
     [sys.executable, str(tools / "backtest.py"), "run"] + sys.argv[1:],
     capture_output=True,
     text=True,
+    encoding="utf-8",
     timeout=120,
 )
 sys.stdout.write(result.stdout)

--- a/skills/volume-breakout/scripts/gather.py
+++ b/skills/volume-breakout/scripts/gather.py
@@ -5,11 +5,18 @@ import subprocess
 import sys
 from pathlib import Path
 
+# Windows defaults stdio to a legacy code page (cp1252); force UTF-8 so the
+# child's Chinese output both decodes and re-prints here without crashing.
+for _s in (sys.stdout, sys.stderr):
+    if hasattr(_s, "reconfigure"):
+        _s.reconfigure(encoding="utf-8")
+
 tools = Path(__file__).resolve().parents[2] / "tools"
 result = subprocess.run(
     [sys.executable, str(tools / "gather.py"), "technical", sys.argv[1], "--kline-count", "90"],
     capture_output=True,
     text=True,
+    encoding="utf-8",
 )
 sys.stdout.write(result.stdout)
 sys.exit(result.returncode)

--- a/skills/wave-theory/scripts/gather.py
+++ b/skills/wave-theory/scripts/gather.py
@@ -5,11 +5,18 @@ import subprocess
 import sys
 from pathlib import Path
 
+# Windows defaults stdio to a legacy code page (cp1252); force UTF-8 so the
+# child's Chinese output both decodes and re-prints here without crashing.
+for _s in (sys.stdout, sys.stderr):
+    if hasattr(_s, "reconfigure"):
+        _s.reconfigure(encoding="utf-8")
+
 tools = Path(__file__).resolve().parents[2] / "tools"
 result = subprocess.run(
     [sys.executable, str(tools / "gather.py"), "technical", sys.argv[1], "--kline-count", "120"],
     capture_output=True,
     text=True,
+    encoding="utf-8",
 )
 sys.stdout.write(result.stdout)
 sys.exit(result.returncode)

--- a/tests/e2e/test_host_to_python.py
+++ b/tests/e2e/test_host_to_python.py
@@ -24,7 +24,7 @@ TOOLS_DIR = PROJECT_ROOT / "tools"
 def _run_cli(script: str, args: list[str], timeout: int = 30) -> dict:
     """Run tools/<script> with args, return parsed JSON stdout."""
     cmd = [sys.executable, str(TOOLS_DIR / script)] + args
-    r = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
+    r = subprocess.run(cmd, capture_output=True, text=True, encoding="utf-8", timeout=timeout)
     assert r.returncode == 0, f"exit {r.returncode}\nstderr: {r.stderr}"
     return json.loads(r.stdout)
 

--- a/tests/e2e/test_pi_e2e.ts
+++ b/tests/e2e/test_pi_e2e.ts
@@ -20,9 +20,9 @@ const venvPython = join(
   repoRoot,
   ".venv",
   isWin ? "Scripts" : "bin",
-  "python3"
+  isWin ? "python.exe" : "python3"
 );
-const python = existsSync(venvPython) ? venvPython : "python3";
+const python = existsSync(venvPython) ? venvPython : isWin ? "python" : "python3";
 
 // --- Load pi/index.ts and capture the tool registrations ------------------
 

--- a/tests/e2e/test_pi_e2e.ts
+++ b/tests/e2e/test_pi_e2e.ts
@@ -6,23 +6,16 @@
 
 import { fileURLToPath } from "url";
 import { dirname, join } from "path";
-import { existsSync } from "fs";
 import { createJiti } from "jiti";
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
+import { resolvePython } from "../../scripts/venv-python.mjs";
 
 const execFileAsync = promisify(execFile);
 
 const here = dirname(fileURLToPath(import.meta.url));
 const repoRoot = join(here, "..", "..");
-const isWin = process.platform === "win32";
-const venvPython = join(
-  repoRoot,
-  ".venv",
-  isWin ? "Scripts" : "bin",
-  isWin ? "python.exe" : "python3"
-);
-const python = existsSync(venvPython) ? venvPython : isWin ? "python" : "python3";
+const python = resolvePython(repoRoot);
 
 // --- Load pi/index.ts and capture the tool registrations ------------------
 

--- a/tests/e2e/test_pi_llm.ts
+++ b/tests/e2e/test_pi_llm.ts
@@ -9,10 +9,10 @@
 
 import { fileURLToPath } from "url";
 import { dirname, join } from "path";
-import { existsSync } from "fs";
 import { createJiti } from "jiti";
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
+import { resolvePython } from "../../scripts/venv-python.mjs";
 import OpenAI from "openai";
 
 const execFileAsync = promisify(execFile);
@@ -27,9 +27,7 @@ const MODEL = process.env.DEEPSEEK_MODEL || "deepseek-v4-flash";
 
 const here = dirname(fileURLToPath(import.meta.url));
 const repoRoot = join(here, "..", "..");
-const isWin = process.platform === "win32";
-const venvPython = join(repoRoot, ".venv", isWin ? "Scripts" : "bin", isWin ? "python.exe" : "python3");
-const python = existsSync(venvPython) ? venvPython : isWin ? "python" : "python3";
+const python = resolvePython(repoRoot);
 
 // --- Load Pi and capture tool registrations -------------------------------
 

--- a/tests/e2e/test_pi_llm.ts
+++ b/tests/e2e/test_pi_llm.ts
@@ -28,8 +28,8 @@ const MODEL = process.env.DEEPSEEK_MODEL || "deepseek-v4-flash";
 const here = dirname(fileURLToPath(import.meta.url));
 const repoRoot = join(here, "..", "..");
 const isWin = process.platform === "win32";
-const venvPython = join(repoRoot, ".venv", isWin ? "Scripts" : "bin", "python3");
-const python = existsSync(venvPython) ? venvPython : "python3";
+const venvPython = join(repoRoot, ".venv", isWin ? "Scripts" : "bin", isWin ? "python.exe" : "python3");
+const python = existsSync(venvPython) ? venvPython : isWin ? "python" : "python3";
 
 // --- Load Pi and capture tool registrations -------------------------------
 

--- a/tests/e2e/test_provider_network.py
+++ b/tests/e2e/test_provider_network.py
@@ -25,7 +25,7 @@ pytestmark = pytest.mark.integration_network
 
 def _run_cli(script: str, args: list[str], timeout: int = 60) -> dict | list:
     cmd = [sys.executable, str(TOOLS_DIR / script)] + args
-    r = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
+    r = subprocess.run(cmd, capture_output=True, text=True, encoding="utf-8", timeout=timeout)
     assert r.returncode == 0, f"exit {r.returncode}\nstderr: {r.stderr[:500]}"
     return json.loads(r.stdout)
 

--- a/tests/test_gather.py
+++ b/tests/test_gather.py
@@ -60,6 +60,7 @@ class TestRun:
             ["/usr/bin/python3", str(TOOLS_DIR / "stock_data.py"), "quote", "600519"],
             capture_output=True,
             text=True,
+            encoding="utf-8",
             timeout=60,
         )
 
@@ -100,6 +101,7 @@ class TestRun:
             ["/usr/bin/python3", str(TOOLS_DIR / "screener.py"), "screen"],
             capture_output=True,
             text=True,
+            encoding="utf-8",
             timeout=120,
         )
 

--- a/tests/test_openclaw_integration.ts
+++ b/tests/test_openclaw_integration.ts
@@ -241,8 +241,9 @@ for (const tool of tools) {
     `${tool.name}: execute did not call Python`
   );
   const lastCall = execCalls[execCalls.length - 1];
+  const scriptPath = lastCall.script.replace(/\\/g, "/"); // tolerate Windows separators
   assert(
-    lastCall.script.endsWith(".py") && lastCall.script.includes("/tools/"),
+    scriptPath.endsWith(".py") && scriptPath.includes("/tools/"),
     `${tool.name}: should invoke a script under tools/, got ${lastCall.script}`
   );
 }

--- a/tests/test_report_renderer.py
+++ b/tests/test_report_renderer.py
@@ -89,6 +89,7 @@ class TestCLI:
             [sys.executable, str(RENDERER_SCRIPT), "stock", "--template", "brief", "--input-b64", payload],
             capture_output=True,
             text=True,
+            encoding="utf-8",
             timeout=30,
         )
         assert r.returncode == 0, f"stderr: {r.stderr}"

--- a/tools/alert_rules.py
+++ b/tools/alert_rules.py
@@ -25,7 +25,7 @@ def _find_python() -> str:
 def _run_json(script: str, args: list[str], timeout: int = 30):
     cmd = [_find_python(), str(TOOLS_DIR / script)] + args
     try:
-        r = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
+        r = subprocess.run(cmd, capture_output=True, text=True, encoding="utf-8", timeout=timeout)
         if r.returncode == 0 and r.stdout.strip():
             return json.loads(r.stdout)
     except Exception:
@@ -235,4 +235,9 @@ def main():
 
 
 if __name__ == "__main__":
+    # Windows defaults stdio to a legacy code page (cp1252) that cannot encode the
+    # Chinese text these tools emit — force UTF-8 so stdout never crashes there.
+    for _s in (sys.stdout, sys.stderr):
+        if hasattr(_s, "reconfigure"):
+            _s.reconfigure(encoding="utf-8")
     main()

--- a/tools/anomaly_detect.py
+++ b/tools/anomaly_detect.py
@@ -22,7 +22,7 @@ TOOLS_DIR = os.path.dirname(os.path.abspath(__file__))
 def _run_tool(script: str, args: str):
     cmd = f"{sys.executable} {TOOLS_DIR}/{script} {args}"
     try:
-        r = subprocess.run(cmd, shell=True, capture_output=True, text=True, timeout=30)
+        r = subprocess.run(cmd, shell=True, capture_output=True, text=True, encoding="utf-8", timeout=30)
         if r.returncode == 0 and r.stdout.strip():
             return json.loads(r.stdout)
     except Exception:
@@ -567,4 +567,9 @@ def main():
 
 
 if __name__ == "__main__":
+    # Windows defaults stdio to a legacy code page (cp1252) that cannot encode the
+    # Chinese text these tools emit — force UTF-8 so stdout never crashes there.
+    for _s in (sys.stdout, sys.stderr):
+        if hasattr(_s, "reconfigure"):
+            _s.reconfigure(encoding="utf-8")
     main()

--- a/tools/backtest.py
+++ b/tools/backtest.py
@@ -755,4 +755,9 @@ def main():
 
 
 if __name__ == "__main__":
+    # Windows defaults stdio to a legacy code page (cp1252) that cannot encode the
+    # Chinese text these tools emit — force UTF-8 so stdout never crashes there.
+    for _s in (sys.stdout, sys.stderr):
+        if hasattr(_s, "reconfigure"):
+            _s.reconfigure(encoding="utf-8")
     main()

--- a/tools/backtest.py
+++ b/tools/backtest.py
@@ -68,6 +68,7 @@ def fetch_kline(symbol: str, start: str | None, end: str | None) -> pd.DataFrame
         [sys.executable, script, "kline", symbol, "--period", "daily", "--count", str(count)],
         capture_output=True,
         text=True,
+        encoding="utf-8",
     )
     data = json.loads(r.stdout)
     if isinstance(data, dict) and "error" in data:

--- a/tools/capabilities.py
+++ b/tools/capabilities.py
@@ -100,4 +100,9 @@ def main():
 
 
 if __name__ == "__main__":
+    # Windows defaults stdio to a legacy code page (cp1252) that cannot encode the
+    # Chinese text these tools emit — force UTF-8 so stdout never crashes there.
+    for _s in (sys.stdout, sys.stderr):
+        if hasattr(_s, "reconfigure"):
+            _s.reconfigure(encoding="utf-8")
     main()

--- a/tools/diagnostics.py
+++ b/tools/diagnostics.py
@@ -138,4 +138,9 @@ def main():
 
 
 if __name__ == "__main__":
+    # Windows defaults stdio to a legacy code page (cp1252) that cannot encode the
+    # Chinese text these tools emit — force UTF-8 so stdout never crashes there.
+    for _s in (sys.stdout, sys.stderr):
+        if hasattr(_s, "reconfigure"):
+            _s.reconfigure(encoding="utf-8")
     main()

--- a/tools/gather.py
+++ b/tools/gather.py
@@ -22,7 +22,7 @@ def _run(script: str, args: list[str], timeout: int = 60) -> str | None:
     python = _find_python()
     cmd = [python, str(TOOLS_DIR / script)] + args
     try:
-        r = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
+        r = subprocess.run(cmd, capture_output=True, text=True, encoding="utf-8", timeout=timeout)
         if r.returncode == 0 and r.stdout.strip():
             return r.stdout.strip()
     except subprocess.TimeoutExpired:
@@ -149,4 +149,9 @@ def main():
 
 
 if __name__ == "__main__":
+    # Windows defaults stdio to a legacy code page (cp1252) that cannot encode the
+    # Chinese text these tools emit — force UTF-8 so stdout never crashes there.
+    for _s in (sys.stdout, sys.stderr):
+        if hasattr(_s, "reconfigure"):
+            _s.reconfigure(encoding="utf-8")
     main()

--- a/tools/import_parser.py
+++ b/tools/import_parser.py
@@ -271,4 +271,9 @@ def main():
 
 
 if __name__ == "__main__":
+    # Windows defaults stdio to a legacy code page (cp1252) that cannot encode the
+    # Chinese text these tools emit — force UTF-8 so stdout never crashes there.
+    for _s in (sys.stdout, sys.stderr):
+        if hasattr(_s, "reconfigure"):
+            _s.reconfigure(encoding="utf-8")
     main()

--- a/tools/market_regime.py
+++ b/tools/market_regime.py
@@ -13,7 +13,7 @@ TOOLS_DIR = os.path.dirname(os.path.abspath(__file__))
 def _run_tool(script: str, args: str) -> dict | list:
     cmd = f"python3 {TOOLS_DIR}/{script} {args}"
     try:
-        r = subprocess.run(cmd, shell=True, capture_output=True, text=True, timeout=30)
+        r = subprocess.run(cmd, shell=True, capture_output=True, text=True, encoding="utf-8", timeout=30)
         if r.returncode == 0 and r.stdout.strip():
             return json.loads(r.stdout)
     except Exception:
@@ -244,4 +244,9 @@ def main():
 
 
 if __name__ == "__main__":
+    # Windows defaults stdio to a legacy code page (cp1252) that cannot encode the
+    # Chinese text these tools emit — force UTF-8 so stdout never crashes there.
+    for _s in (sys.stdout, sys.stderr):
+        if hasattr(_s, "reconfigure"):
+            _s.reconfigure(encoding="utf-8")
     main()

--- a/tools/market_review.py
+++ b/tools/market_review.py
@@ -14,7 +14,7 @@ TOOLS_DIR = os.path.dirname(os.path.abspath(__file__))
 def _run_tool(script: str, args: str, timeout: int = 30):
     cmd = [sys.executable, os.path.join(TOOLS_DIR, script)] + args.split()
     try:
-        r = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
+        r = subprocess.run(cmd, capture_output=True, text=True, encoding="utf-8", timeout=timeout)
         if r.returncode == 0 and r.stdout.strip():
             return json.loads(r.stdout)
     except Exception:
@@ -147,4 +147,9 @@ def main():
 
 
 if __name__ == "__main__":
+    # Windows defaults stdio to a legacy code page (cp1252) that cannot encode the
+    # Chinese text these tools emit — force UTF-8 so stdout never crashes there.
+    for _s in (sys.stdout, sys.stderr):
+        if hasattr(_s, "reconfigure"):
+            _s.reconfigure(encoding="utf-8")
     main()

--- a/tools/name_resolver.py
+++ b/tools/name_resolver.py
@@ -128,4 +128,9 @@ def main():
 
 
 if __name__ == "__main__":
+    # Windows defaults stdio to a legacy code page (cp1252) that cannot encode the
+    # Chinese text these tools emit — force UTF-8 so stdout never crashes there.
+    for _s in (sys.stdout, sys.stderr):
+        if hasattr(_s, "reconfigure"):
+            _s.reconfigure(encoding="utf-8")
     main()

--- a/tools/pattern.py
+++ b/tools/pattern.py
@@ -17,6 +17,7 @@ def fetch_kline(symbol: str, period: str = "daily", count: int = 60) -> list:
         [sys.executable, script, "kline", symbol, "--period", period, "--count", str(count)],
         capture_output=True,
         text=True,
+        encoding="utf-8",
     )
     return json.loads(r.stdout)
 

--- a/tools/pattern.py
+++ b/tools/pattern.py
@@ -506,4 +506,9 @@ def main():
 
 
 if __name__ == "__main__":
+    # Windows defaults stdio to a legacy code page (cp1252) that cannot encode the
+    # Chinese text these tools emit — force UTF-8 so stdout never crashes there.
+    for _s in (sys.stdout, sys.stderr):
+        if hasattr(_s, "reconfigure"):
+            _s.reconfigure(encoding="utf-8")
     main()

--- a/tools/position_context.py
+++ b/tools/position_context.py
@@ -25,7 +25,7 @@ def _find_python() -> str:
 def _run_json(script: str, args: list[str], timeout: int = 30):
     cmd = [_find_python(), str(TOOLS_DIR / script)] + args
     try:
-        r = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
+        r = subprocess.run(cmd, capture_output=True, text=True, encoding="utf-8", timeout=timeout)
         if r.returncode == 0 and r.stdout.strip():
             return json.loads(r.stdout)
     except Exception:
@@ -153,4 +153,9 @@ def main():
 
 
 if __name__ == "__main__":
+    # Windows defaults stdio to a legacy code page (cp1252) that cannot encode the
+    # Chinese text these tools emit — force UTF-8 so stdout never crashes there.
+    for _s in (sys.stdout, sys.stderr):
+        if hasattr(_s, "reconfigure"):
+            _s.reconfigure(encoding="utf-8")
     main()

--- a/tools/report_renderer.py
+++ b/tools/report_renderer.py
@@ -108,4 +108,9 @@ def main():
 
 
 if __name__ == "__main__":
+    # Windows defaults stdio to a legacy code page (cp1252) that cannot encode the
+    # Chinese text these tools emit — force UTF-8 so stdout never crashes there.
+    for _s in (sys.stdout, sys.stderr):
+        if hasattr(_s, "reconfigure"):
+            _s.reconfigure(encoding="utf-8")
     main()

--- a/tools/risk_screening.py
+++ b/tools/risk_screening.py
@@ -14,7 +14,7 @@ TOOLS_DIR = os.path.dirname(os.path.abspath(__file__))
 def _run_tool(script: str, args: str) -> dict:
     cmd = f"python3 {TOOLS_DIR}/{script} {args}"
     try:
-        r = subprocess.run(cmd, shell=True, capture_output=True, text=True, timeout=30)
+        r = subprocess.run(cmd, shell=True, capture_output=True, text=True, encoding="utf-8", timeout=30)
         if r.returncode == 0 and r.stdout.strip():
             return json.loads(r.stdout)
     except Exception:
@@ -315,4 +315,9 @@ def main():
 
 
 if __name__ == "__main__":
+    # Windows defaults stdio to a legacy code page (cp1252) that cannot encode the
+    # Chinese text these tools emit — force UTF-8 so stdout never crashes there.
+    for _s in (sys.stdout, sys.stderr):
+        if hasattr(_s, "reconfigure"):
+            _s.reconfigure(encoding="utf-8")
     main()

--- a/tools/screener.py
+++ b/tools/screener.py
@@ -31,6 +31,7 @@ def fetch_snapshot(market: str) -> list:
         [sys.executable, script, "market_snapshot", "--market", market],
         capture_output=True,
         text=True,
+        encoding="utf-8",
     )
     return json.loads(r.stdout)
 

--- a/tools/screener.py
+++ b/tools/screener.py
@@ -210,4 +210,9 @@ def main():
 
 
 if __name__ == "__main__":
+    # Windows defaults stdio to a legacy code page (cp1252) that cannot encode the
+    # Chinese text these tools emit — force UTF-8 so stdout never crashes there.
+    for _s in (sys.stdout, sys.stderr):
+        if hasattr(_s, "reconfigure"):
+            _s.reconfigure(encoding="utf-8")
     main()

--- a/tools/search_intel.py
+++ b/tools/search_intel.py
@@ -496,4 +496,9 @@ def main():
 
 
 if __name__ == "__main__":
+    # Windows defaults stdio to a legacy code page (cp1252) that cannot encode the
+    # Chinese text these tools emit — force UTF-8 so stdout never crashes there.
+    for _s in (sys.stdout, sys.stderr):
+        if hasattr(_s, "reconfigure"):
+            _s.reconfigure(encoding="utf-8")
     main()

--- a/tools/stock_data.py
+++ b/tools/stock_data.py
@@ -1712,4 +1712,9 @@ def main():
 
 
 if __name__ == "__main__":
+    # Windows defaults stdio to a legacy code page (cp1252) that cannot encode the
+    # Chinese text these tools emit — force UTF-8 so stdout never crashes there.
+    for _s in (sys.stdout, sys.stderr):
+        if hasattr(_s, "reconfigure"):
+            _s.reconfigure(encoding="utf-8")
     main()

--- a/tools/stock_data.py
+++ b/tools/stock_data.py
@@ -973,6 +973,7 @@ def _news_search_intel_fallback(symbol: str) -> list:
             [sys.executable, str(tools_dir / "search_intel.py"), "search", f"{symbol} 最新消息"],
             capture_output=True,
             text=True,
+            encoding="utf-8",
             timeout=30,
         )
     except (subprocess.TimeoutExpired, OSError):

--- a/tools/technical.py
+++ b/tools/technical.py
@@ -633,4 +633,9 @@ def main():
 
 
 if __name__ == "__main__":
+    # Windows defaults stdio to a legacy code page (cp1252) that cannot encode the
+    # Chinese text these tools emit — force UTF-8 so stdout never crashes there.
+    for _s in (sys.stdout, sys.stderr):
+        if hasattr(_s, "reconfigure"):
+            _s.reconfigure(encoding="utf-8")
     main()

--- a/tools/technical.py
+++ b/tools/technical.py
@@ -17,6 +17,7 @@ def fetch_kline(symbol: str, period: str = "daily", count: int = 120) -> list:
         [sys.executable, script, "kline", symbol, "--period", period, "--count", str(count)],
         capture_output=True,
         text=True,
+        encoding="utf-8",
     )
     return json.loads(r.stdout)
 

--- a/tools/trading_calendar.py
+++ b/tools/trading_calendar.py
@@ -218,4 +218,9 @@ def main():
 
 
 if __name__ == "__main__":
+    # Windows defaults stdio to a legacy code page (cp1252) that cannot encode the
+    # Chinese text these tools emit — force UTF-8 so stdout never crashes there.
+    for _s in (sys.stdout, sys.stderr):
+        if hasattr(_s, "reconfigure"):
+            _s.reconfigure(encoding="utf-8")
     main()

--- a/tools/volume_analysis.py
+++ b/tools/volume_analysis.py
@@ -169,4 +169,9 @@ def main():
 
 
 if __name__ == "__main__":
+    # Windows defaults stdio to a legacy code page (cp1252) that cannot encode the
+    # Chinese text these tools emit — force UTF-8 so stdout never crashes there.
+    for _s in (sys.stdout, sys.stderr):
+        if hasattr(_s, "reconfigure"):
+            _s.reconfigure(encoding="utf-8")
     main()

--- a/tools/volume_analysis.py
+++ b/tools/volume_analysis.py
@@ -17,6 +17,7 @@ def fetch_kline(symbol: str, period: str = "daily", count: int = 60) -> list:
         [sys.executable, script, "kline", symbol, "--period", period, "--count", str(count)],
         capture_output=True,
         text=True,
+        encoding="utf-8",
     )
     return json.loads(r.stdout)
 

--- a/tools/watchlist.py
+++ b/tools/watchlist.py
@@ -58,4 +58,9 @@ def main():
 
 
 if __name__ == "__main__":
+    # Windows defaults stdio to a legacy code page (cp1252) that cannot encode the
+    # Chinese text these tools emit — force UTF-8 so stdout never crashes there.
+    for _s in (sys.stdout, sys.stderr):
+        if hasattr(_s, "reconfigure"):
+            _s.reconfigure(encoding="utf-8")
     main()

--- a/tools/watchlist_context.py
+++ b/tools/watchlist_context.py
@@ -28,7 +28,7 @@ def _find_python() -> str:
 def _run_json(script: str, args: list[str], timeout: int = 30):
     cmd = [_find_python(), str(TOOLS_DIR / script)] + args
     try:
-        r = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
+        r = subprocess.run(cmd, capture_output=True, text=True, encoding="utf-8", timeout=timeout)
         if r.returncode == 0 and r.stdout.strip():
             return json.loads(r.stdout)
     except Exception:
@@ -177,4 +177,9 @@ def main():
 
 
 if __name__ == "__main__":
+    # Windows defaults stdio to a legacy code page (cp1252) that cannot encode the
+    # Chinese text these tools emit — force UTF-8 so stdout never crashes there.
+    for _s in (sys.stdout, sys.stderr):
+        if hasattr(_s, "reconfigure"):
+            _s.reconfigure(encoding="utf-8")
     main()


### PR DESCRIPTION
## 背景

issue #2 的 Windows 崩溃（以及本次三宿主 venv 路径修复）之所以长期没被发现，是因为 **CI 所有 job 都跑在 `ubuntu-latest`** —— 任何 OS 特定的路径 bug（Windows venv 的 `python.exe` 位置、`__dirname`/baseDir 解析）都结构性看不到。

## 改动

新增 **`compat` job**，在三个免费 runner(`ubuntu-latest` / `macos-latest` / `windows-latest`）上跑**确定性的宿主↔python 集成**:

- `tsc --noEmit`
- pi / openclaw 扩展注册（jiti 加载 + skill 路径解析 → 覆盖 baseDir/`__dirname`/`import.meta` 逻辑）
- hermes 扩展注册（skill 文件路径）
- **pi / openclaw 真实子进程 round-trip**（实际 spawn 插件解析出的 python 跑工具 → 直接覆盖 #2 的 Windows venv 解析）

无 LLM、无 secrets、4 个 round-trip 工具均为非网络集合（见 `tests/e2e/*.ts` 注释），快速且稳定。

## 为让 Windows leg 能过而修的前置问题

| 文件 | 问题 | 修复 |
|---|---|---|
| `scripts/setup-python.mjs` | `URL.pathname` 在 Windows 得到 `/C:/...` 非法路径，postinstall 建 venv 会放错位置或失败 | 改用 `fileURLToPath`;pip 调用改用 venv 自带 `python -m pip`（不再依赖 `pip`/`pip.exe` shim 解析） |
| `tests/e2e/test_pi_e2e.ts`、`test_pi_llm.ts` | harness 自己的 venv-python 解析也硬编 `Scripts/python3`（与 #2 同根因，虽是测试脚手架） | 与插件逻辑对齐：win32 用 `python.exe`、回退 `python` |

依赖安装做了精简：系统 python 只装 `requirements-dev.txt`(hermes 测试只需 pytest —— `schemas.py` 零 import、`tools.py` 全 stdlib)；重依赖仅由 `.venv`(npm postinstall）装一份，供 round-trip 子进程用。

## 明确不做的

LLM `e2e-host` job 维持 **ubuntu-only**:`host_smoke.mjs` 硬编 `bin/pip`、`python3.1x`，且需 secrets + 真实宿主 CLI，让它 Windows 可移植是独立的一摊工作。需要的话另开 PR。

## 验证

- macOS 本地：compat job 全部 6 项命令通过（含 pi 真实子进程 round-trip)。
- ubuntu 与 macOS 同为 POSIX 路径，风险低；**Windows leg 以本 PR 的真实 CI 结果为准**，如有问题我在本 PR 内迭代修掉。

Refs #2
