### PR TITLE
feat: dsh (DeepSeek Harness) plugin — 第四宿主适配 + e2e 冒烟

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,9 @@ jobs:
       - name: Test OpenClaw plugin registration
         run: npx tsx tests/test_openclaw_integration.ts
 
+      - name: Test dsh plugin registration
+        run: npx tsx tests/test_dsh_integration.ts
+
       - name: E2E — host↔python round-trip (pytest)
         run: pytest tests/e2e/test_host_to_python.py -v
 
@@ -92,6 +95,9 @@ jobs:
 
       - name: E2E — OpenClaw host real subprocess
         run: npx tsx tests/e2e/test_openclaw_e2e.ts
+
+      - name: E2E — dsh host real subprocess
+        run: npx tsx tests/e2e/test_dsh_e2e.ts
 
   compat:
     # Cross-platform host↔python integration on the free runners. This is the
@@ -134,6 +140,9 @@ jobs:
       - name: OpenClaw plugin registration
         run: npx tsx tests/test_openclaw_integration.ts
 
+      - name: dsh plugin registration
+        run: npx tsx tests/test_dsh_integration.ts
+
       - name: Hermes plugin registration
         run: pytest tests/test_hermes_integration.py -v
 
@@ -142,6 +151,9 @@ jobs:
 
       - name: OpenClaw host real subprocess round-trip
         run: npx tsx tests/e2e/test_openclaw_e2e.ts
+
+      - name: dsh host real subprocess round-trip
+        run: npx tsx tests/e2e/test_dsh_e2e.ts
 
   e2e-llm:
     # Real DeepSeek call. Only runs when DEEPSEEK_API_KEY secret is present
@@ -192,14 +204,15 @@ jobs:
 
   e2e-host:
     # Real-host smoke: install the plugin into the actual pi / openclaw /
-    # hermes runtime and run one QA turn through the host's own agent loop.
-    # This is a BLOCKING check — the smoke script retries the QA internally.
+    # hermes / dsh runtime and run one QA turn through the host's own agent
+    # loop. This is a BLOCKING check — the smoke script retries the QA
+    # internally.
     runs-on: ubuntu-latest
     if: ${{ github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository }}
     strategy:
       fail-fast: false
       matrix:
-        host: [pi, openclaw, hermes]
+        host: [pi, openclaw, hermes, dsh]
     timeout-minutes: 25
     steps:
       - uses: actions/checkout@v4
@@ -210,6 +223,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         # Node 24: openclaw requires >= 22.19, and pi 0.83's undici breaks on 20.x
+        # (dsh also requires ^22.19 || >=24)
         with:
           node-version: "24"
 
@@ -219,10 +233,13 @@ jobs:
       - name: Install host CLIs
         # Pinned: pi latest and openclaw latest (slim repack) drifted from the
         # validated CLIs — openclaw@latest installed no working bin, and pi's
-        # `list` flags changed between releases.
+        # `list` flags changed between releases. dsh is a developer preview
+        # (rc line), so pin it too. `dsh plugin` forwards to pnpm.
         run: |
           npm i -g @earendil-works/pi-coding-agent@0.83.0
           npm i -g openclaw@2026.6.33
+          npm i -g @deepseek-ai/dsh@0.1.0-rc.7
+          npm i -g pnpm@10
 
       - name: Real-host smoke QA (${{ matrix.host }})
         env:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -193,9 +193,60 @@ jobs:
       - name: Publish to ClawHub
         run: clawhub package publish ./openclaw
 
+  publish-dsh:
+    runs-on: ubuntu-latest
+    needs: [lint, test]
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Sync version from tag
+        run: bash scripts/sync-version.sh
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Build compiled plugin entry (dist/index.js)
+        run: npm run build:dsh
+
+      - name: Stage payload into dsh/
+        run: |
+          set -euo pipefail
+          for d in tools skills schemas templates strategies scripts; do
+            if [ -d "$d" ]; then
+              rm -rf "dsh/$d"
+              cp -R "$d" "dsh/$d"
+            fi
+          done
+
+      # Same regression guard as the OpenClaw job: the dsh profile loader
+      # imports built JS, so dist must survive the `files` whitelist, and the
+      # bundle manifest must ship its patch file.
+      - name: Verify compiled entry and patch are packaged
+        working-directory: dsh
+        run: |
+          npm pack --dry-run 2>&1 | tee pack-dry-run.txt
+          grep -q "dist/index.js" pack-dry-run.txt \
+            || { echo "::error::dist/index.js missing from dsh npm tarball — build ran but files whitelist excludes dist/"; exit 1; }
+          grep -q "cordis.patch.yml" pack-dry-run.txt \
+            || { echo "::error::cordis.patch.yml missing from dsh npm tarball — dsh bundle manifest would dangle"; exit 1; }
+
+      - name: npm publish
+        working-directory: dsh
+        run: npm publish --access public --provenance
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
   github-release:
     runs-on: ubuntu-latest
-    needs: [publish-npm, publish-pypi, publish-openclaw]
+    needs: [publish-npm, publish-pypi, publish-openclaw, publish-dsh]
     permissions:
       contents: write
     steps:
@@ -214,6 +265,7 @@ jobs:
           - **npm**: \`npm install @weaxs/stock-analysis-plugin@${VERSION}\`
           - **pip**: \`pip install stock-analysis-plugin==${VERSION}\`
           - **OpenClaw**: \`openclaw plugins install clawhub:@weaxs/openclaw-stock-analysis\`
+          - **dsh**: \`dsh plugin --profile <name> add @weaxs/dsh-stock-analysis\`
           EOF
 
       - name: Create GitHub Release

--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,12 @@ openclaw/templates/
 openclaw/strategies/
 openclaw/scripts/
 openclaw/*.tgz
+
+# dsh staged publish payload (see publish.yml "Stage payload into dsh/")
+dsh/tools/
+dsh/skills/
+dsh/schemas/
+dsh/templates/
+dsh/strategies/
+dsh/scripts/
+dsh/*.tgz

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,17 +2,18 @@
 
 ## Project Overview
 
-A multi-host agent plugin for stock analysis, screening, and strategy backtesting across **A / HK / US / JP / KR / TW** markets. The same capability ships as a **Pi Agent** extension, a **Hermes Agent** plugin, and an **OpenClaw** plugin.
+A multi-host agent plugin for stock analysis, screening, and strategy backtesting across **A / HK / US / JP / KR / TW** markets. The same capability ships as a **Pi Agent** extension, a **Hermes Agent** plugin, an **OpenClaw** plugin, and a **DeepSeek Harness (dsh)** plugin.
 
-The architecture is **one Python core, three thin host adapters**:
+The architecture is **one Python core, four thin host adapters**:
 
 - `tools/*.py` — the shared CLI tools. **This is the single source of truth** for all behavior. Every tool prints JSON to stdout.
 - `pi/index.ts` — Pi extension. `pi.registerTool` ×39, each spawns a `tools/*.py` CLI.
 - `hermes/` — Hermes plugin (`plugin.yaml` + `register(ctx)` in `__init__.py`; `tools.py` handlers → subprocess to the same CLIs). Discovered via the `hermes_agent.plugins` entry point.
 - `openclaw/` — OpenClaw plugin (`openclaw.plugin.json` manifest + `index.ts` `definePluginEntry` + `registerTool` ×39). Bundled with esbuild.
-- `skills/*/SKILL.md` — 20 workflow / strategy-methodology skills shared by all three hosts.
+- `dsh/` — dsh bundle (`package.json` `dsh.bundle` + `cordis.patch.yml` + `index.ts` cordis `apply(ctx)` with `defineTool` ×39 via `@deepseek-ai/dsh-tools`; skills via `ctx.skills.register`). Bundled with esbuild, `@deepseek-ai/*` external (peer deps).
+- `skills/*/SKILL.md` — 20 workflow / strategy-methodology skills shared by all four hosts.
 
-> **The invariant that matters most:** the three adapters expose the *same* 39 tools over the *same* Python CLIs. A change to a tool's name, parameters, or JSON output shape must be applied to **all three adapters and the relevant SKILL.md together** — never just one.
+> **The invariant that matters most:** the four adapters expose the *same* 39 tools over the *same* Python CLIs. A change to a tool's name, parameters, or JSON output shape must be applied to **all four adapters and the relevant SKILL.md together** — never just one.
 
 ---
 
@@ -28,7 +29,7 @@ Every code change follows ponytail's ladder — stop at the first rung that hold
 
 ```
 1. Does this need to exist?   → no: skip it (YAGNI)
-2. Already in this codebase?  → reuse it, don't rewrite (check tools/ and the three host adapters first)
+2. Already in this codebase?  → reuse it, don't rewrite (check tools/ and the four host adapters first)
 3. Stdlib does it?            → use it
 4. Native platform feature?   → use it
 5. Installed dependency?      → use it — no new deps for one-call problems
@@ -60,7 +61,7 @@ Files the skills.sh installer copies into the repo are local tooling — do not 
 
 ---
 
-## Architecture: One Core, Three Adapters
+## Architecture: One Core, Four Adapters
 
 All real work happens in `tools/*.py`. The adapters only translate a host-native tool call into a subprocess invocation of a CLI and relay the JSON stdout back. Keep them thin — no business logic in TypeScript or in `hermes/tools.py` beyond argument mapping and subprocess plumbing.
 
@@ -97,6 +98,19 @@ def get_kline(args: dict, **kwargs) -> str:
 // definePluginEntry + typebox schemas. The executor is indirected via
 // __setExecutor() so tests can stub it without touching node:child_process.
 // toolsDir has a dev vs published fallback; venv has a repo-root vs staged-payload fallback.
+```
+
+### dsh — `dsh/index.ts`
+
+```typescript
+// Cordis function-plugin form: `export const name/inject` + `apply(ctx)`.
+// Each tool is defineTool() (dsh's JSON-Schema-subset DSL — `required: true`
+// per property, enums as `enum: [...]`) registered via ctx.tools.register;
+// execute() returns the CLI's raw JSON text and output.render relays it as
+// one text block. The package is a dsh *bundle*: package.json carries
+// `dsh.bundle.patch` and cordis.patch.yml inserts the entry into a profile.
+// @deepseek-ai/* stay external in the esbuild bundle (peer deps resolved
+// from the profile); skills are registered by scanning skills/*/SKILL.md.
 ```
 
 ---
@@ -142,12 +156,14 @@ Commands:
 .venv/bin/python -m pytest tests/test_hermes_integration.py -v     # Hermes registration
 npx tsx tests/test_pi_integration.ts                       # Pi registration (jiti load + skill paths)
 npx tsx tests/test_openclaw_integration.ts                 # OpenClaw registration
+npx tsx tests/test_dsh_integration.ts                      # dsh registration (tools + skills + bundle manifest)
 .venv/bin/python -m pytest tests/e2e/test_host_to_python.py -v     # host↔python round-trip
 npx tsx tests/e2e/test_pi_e2e.ts                           # Pi real-subprocess e2e
 npx tsx tests/e2e/test_openclaw_e2e.ts                     # OpenClaw real-subprocess e2e
+npx tsx tests/e2e/test_dsh_e2e.ts                          # dsh real-subprocess e2e
 ```
 
-`tests/e2e/host_smoke.mjs <pi|openclaw|hermes>` is the **blocking** real-host smoke (installs the plugin into the actual runtime and runs one QA turn). It needs `SMOKE_LLM_API_KEY` and is a CI gate — run it before releasing, not on every edit.
+`tests/e2e/host_smoke.mjs <pi|openclaw|hermes|dsh>` is the **blocking** real-host smoke (installs the plugin into the actual runtime and runs one QA turn). It needs `SMOKE_LLM_API_KEY` and is a CI gate — run it before releasing, not on every edit.
 
 ---
 
@@ -157,28 +173,28 @@ npx tsx tests/e2e/test_openclaw_e2e.ts                     # OpenClaw real-subpr
 ruff check tools/ skills/ tests/ hermes/          # lint
 ruff format --check tools/ skills/ tests/ hermes/ # format check (autofix.yml auto-fixes on PRs)
 ruff check --fix tools/ skills/ tests/ hermes/ && ruff format tools/ skills/ tests/ hermes/   # apply locally
-npx tsc --noEmit                                  # TS type check (pi/, openclaw/, tests/*.ts)
+npx tsc --noEmit                                  # TS type check (pi/, openclaw/, dsh/, tests/*.ts)
 ```
 
 ---
 
 ## Versioning & Release
 
-Versions live in **four** manifests that must stay in lockstep: `pyproject.toml`, `package.json`, `package-lock.json`, `openclaw/package.json`.
+Versions live in **five** manifests that must stay in lockstep: `pyproject.toml`, `package.json`, `package-lock.json`, `openclaw/package.json`, `dsh/package.json`.
 
-- **Do not hand-edit versions for a release.** Publishing is tag-driven: push a `vX.Y.Z` tag and `publish.yml` runs `scripts/sync-version.sh "$TAG"`, which rewrites all four in-CI (never committed back). The repo's checked-in version is just the last-released baseline.
+- **Do not hand-edit versions for a release.** Publishing is tag-driven: push a `vX.Y.Z` tag and `publish.yml` runs `scripts/sync-version.sh "$TAG"`, which rewrites all five in-CI (never committed back). The repo's checked-in version is just the last-released baseline.
 - `scripts/sync-version.sh` is idempotent and validates the tag shape; you can dry-run it locally with `GITHUB_REF_NAME=v9.9.9 scripts/sync-version.sh`.
 - Verify package contents before publishing: `npm pack --dry-run` (the `build` CI job does this and uploads the tarball).
-- Build the OpenClaw bundle with `npm run build:openclaw` (esbuild → `openclaw/dist/index.js`).
+- Build the OpenClaw bundle with `npm run build:openclaw` (esbuild → `openclaw/dist/index.js`) and the dsh bundle with `npm run build:dsh` (esbuild → `dsh/dist/index.js`, `@deepseek-ai/*` external).
 - The `postinstall` (`scripts/setup-python.mjs`) builds the repo `.venv` and installs `tools/requirements.txt`. Syntax-check it with `node --check scripts/setup-python.mjs` after edits.
 
 ---
 
 ## Implementation Discipline
 
-- **Match the existing adapter you're editing** — read the sibling registrations first and copy their style, argument mapping, and error shape. The three adapters are deliberately parallel; keep them parallel.
-- **One tool = three registrations + docs.** Adding/renaming/re-paraming a tool touches `pi/index.ts`, `openclaw/index.ts`, `hermes/tools.py` + `hermes/schemas.py`, the relevant `skills/*/SKILL.md`, and the README tool table — together, in one change. Don't land a tool in one host only.
-- **Keep the JSON contract stable.** Host adapters and tests parse `tools/` stdout. Changing a key is a breaking change across all three hosts — update all consumers and tests in the same change, or add the new key alongside the old.
+- **Match the existing adapter you're editing** — read the sibling registrations first and copy their style, argument mapping, and error shape. The four adapters are deliberately parallel; keep them parallel.
+- **One tool = four registrations + docs.** Adding/renaming/re-paraming a tool touches `pi/index.ts`, `openclaw/index.ts`, `dsh/index.ts`, `hermes/tools.py` + `hermes/schemas.py`, the relevant `skills/*/SKILL.md`, and the README tool table — together, in one change. Don't land a tool in one host only.
+- **Keep the JSON contract stable.** Host adapters and tests parse `tools/` stdout. Changing a key is a breaking change across all four hosts — update all consumers and tests in the same change, or add the new key alongside the old.
 - Minimal, scoped diffs. Don't "improve" unrelated code or do cross-cutting refactors unless asked.
 - New config keys / tool params need corresponding test coverage (pytest for the core, tsx for the adapter registration).
 - Don't swallow exceptions: expected failures (missing symbol, bad input, provider down) become clean JSON `error` results; unexpected exceptions should not leak raw stack traces or response bodies to the user.
@@ -195,7 +211,7 @@ Versions live in **four** manifests that must stay in lockstep: `pyproject.toml`
 
 ## Code Review Rules
 
-- **Adapter sync** — flag any tool name/param/JSON-shape change that landed in fewer than all three adapters + SKILL.md + README. Safe path: one PR updates every host together.
+- **Adapter sync** — flag any tool name/param/JSON-shape change that landed in fewer than all four adapters + SKILL.md + README. Safe path: one PR updates every host together.
 - **Cross-platform paths** — flag hardcoded `bin/python3`/`Scripts/python.exe`, `__dirname` without the ESM fallback, `URL.pathname`, or pip-shim invocations. Safe path: reuse `scripts/venv-python.mjs` and the existing dev/published and venv/fallback chains.
 - **Host↔Python contract** — flag `tools/` changes that emit non-JSON on stdout, emit secrets/stack traces, or rename output keys without updating all adapters and tests. Safe path: JSON-only stdout, additive key changes, coverage in pytest + tsx.
 - **Dependency additions** — flag new entries to `tools/requirements.txt` / `pyproject.toml` that duplicate stdlib or an installed dep (ponytail rung 5).
@@ -206,10 +222,10 @@ Versions live in **four** manifests that must stay in lockstep: `pyproject.toml`
 
 1. Implement the CLI in the appropriate `tools/*.py` (argparse subcommand, JSON stdout, py3.9-compatible).
 2. Add a failing pytest first (`tests/test_<module>.py`), then make it pass (see `tdd`).
-3. Register it in all three adapters: `pi/index.ts`, `openclaw/index.ts`, `hermes/tools.py` + `hermes/schemas.py` — same name, same params.
+3. Register it in all four adapters: `pi/index.ts`, `openclaw/index.ts`, `dsh/index.ts`, `hermes/tools.py` + `hermes/schemas.py` — same name, same params.
 4. Wire it into the relevant `skills/*/SKILL.md` workflow if an agent should call it.
 5. Update the README tool table (and tool count if surfaced).
-6. Verify: `ruff check …`, `npx tsc --noEmit`, pytest, and the three registration tests (`test_pi_integration.ts`, `test_openclaw_integration.ts`, `test_hermes_integration.py`).
+6. Verify: `ruff check …`, `npx tsc --noEmit`, pytest, and the four registration tests (`test_pi_integration.ts`, `test_openclaw_integration.ts`, `test_dsh_integration.ts`, `test_hermes_integration.py`).
 
 ---
 
@@ -220,8 +236,9 @@ npm install                        # also builds repo .venv via postinstall
 ruff check tools/ skills/ tests/ hermes/ && ruff format --check tools/ skills/ tests/ hermes/
 npx tsc --noEmit
 .venv/bin/python -m pytest -q
-npx tsx tests/test_pi_integration.ts && npx tsx tests/test_openclaw_integration.ts
+npx tsx tests/test_pi_integration.ts && npx tsx tests/test_openclaw_integration.ts && npx tsx tests/test_dsh_integration.ts
 .venv/bin/python -m pytest tests/test_hermes_integration.py -v
 npm run build:openclaw             # esbuild bundle for OpenClaw
+npm run build:dsh                  # esbuild bundle for dsh (@deepseek-ai/* external)
 npm pack --dry-run                 # verify publish contents
 ```

--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 [![Python](https://img.shields.io/badge/python-%3E=3.10-blue?logo=python&logoColor=white)](https://www.python.org/)
 
-A 股 / 港股 / 美股 / 日股 / 韩股 / 台股综合分析、多因子选股和策略回测工具集，可作为 [Pi Agent](https://github.com/anthropics/pi-agent) Extension、[Hermes Agent](https://github.com/NousResearch/hermes-agent) Plugin，或 [OpenClaw](https://docs.openclaw.ai/) Plugin 使用。
+A 股 / 港股 / 美股 / 日股 / 韩股 / 台股综合分析、多因子选股和策略回测工具集，可作为 [Pi Agent](https://github.com/anthropics/pi-agent) Extension、[Hermes Agent](https://github.com/NousResearch/hermes-agent) Plugin、[OpenClaw](https://docs.openclaw.ai/) Plugin，或 [DeepSeek Harness (dsh)](https://github.com/deepseek-ai/deepseek-harness) Plugin 使用。
 
-底层共享同一套 Python CLI 工具和 SKILL.md 工作流，上层分别适配三个平台的注册机制。
+底层共享同一套 Python CLI 工具和 SKILL.md 工作流，上层分别适配四个平台的注册机制。
 
 ## 目录
 
@@ -16,6 +16,7 @@ A 股 / 港股 / 美股 / 日股 / 韩股 / 台股综合分析、多因子选股
   - [Pi Agent Extension](#pi-agent-extension)
   - [Hermes Agent Plugin](#hermes-agent-plugin)
   - [OpenClaw Plugin](#openclaw-plugin)
+  - [dsh (DeepSeek Harness) Plugin](#dsh-deepseek-harness-plugin)
   - [Python 依赖](#python-依赖)
 - [快速开始](#快速开始)
 - [Skills 一览](#skills-一览)
@@ -35,7 +36,7 @@ A 股 / 港股 / 美股 / 日股 / 韩股 / 台股综合分析、多因子选股
 - **策略回测引擎** — YAML DSL 定义策略，参数化条件组合，自动诊断 + LLM 变异优化
 - **多数据源 Failover** — 9 个数据源自动容灾切换（akshare / tushare / efinance / pytdx / baostock / yfinance / finnhub / longbridge / alphavantage）
 - **社交舆情增强** — A 股（东财股吧 + 雪球）/ 美港股（Reddit / X / Polymarket），市场自动路由
-- **三平台适配** — 同一套工具同时支持 Pi Agent、Hermes Agent 和 OpenClaw
+- **四平台适配** — 同一套工具同时支持 Pi Agent、Hermes Agent、OpenClaw 和 dsh
 
 ## 安装
 
@@ -78,9 +79,20 @@ register(ctx)
 openclaw plugins install clawhub:@weaxs/openclaw-stock-analysis
 ```
 
-OpenClaw Gateway 启动后自动加载并注册 31 个 tool。安装时 postinstall 会自动建 `.venv` 并装好 Python 依赖（前提：本机有 `python3 >= 3.9`）。
+OpenClaw Gateway 启动后自动加载并注册 39 个 tool。安装时 postinstall 会自动建 `.venv` 并装好 Python 依赖（前提：本机有 `python3 >= 3.9`）。
 
 详见 [OpenClaw 接入指南](docs/openclaw-integration.md)，或 plugin 自身说明 [`openclaw/README.md`](openclaw/README.md)。
+
+### dsh (DeepSeek Harness) Plugin
+
+```bash
+dsh plugin --profile <你的profile> add @weaxs/dsh-stock-analysis
+dsh --profile <你的profile>
+```
+
+作为 dsh bundle 安装：`dsh plugin add` 会把 `cordis.patch.yml` 叠加进 profile 组合，注册 39 个 tool + 20 个 skill。postinstall 自动建 `.venv`（pnpm 需在 profile 的 `pnpm-workspace.yaml` 里给本包配 `allowBuilds`，否则回退系统 `python3`）。
+
+详见 [`dsh/README.md`](dsh/README.md)。
 
 ### Python 依赖
 
@@ -370,16 +382,20 @@ python tools/market_regime.py detect A
 ```
 stock-analysis/
 ├── pi/                              # Pi Agent Extension
-│   └── index.ts                     #   注册 31 个工具 + 20 个 skill
+│   └── index.ts                     #   注册 39 个工具 + 20 个 skill
 ├── hermes/                          # Hermes Agent Plugin
 │   ├── plugin.yaml                  #   插件清单
 │   ├── __init__.py                  #   register(ctx) 入口
 │   ├── schemas.py                   #   工具 JSON Schema 定义
-│   └── tools.py                     #   31 个 handler → subprocess 调 CLI
+│   └── tools.py                     #   39 个 handler → subprocess 调 CLI
 ├── openclaw/                        # OpenClaw Plugin
 │   ├── openclaw.plugin.json         #   manifest（contracts.tools）
 │   ├── package.json                 #   含 openclaw 块（pluginApi/SDK 版本）
-│   └── index.ts                     #   definePluginEntry + registerTool ×31
+│   └── index.ts                     #   definePluginEntry + registerTool ×39
+├── dsh/                             # DeepSeek Harness (dsh) Plugin
+│   ├── cordis.patch.yml             #   bundle patch（insert 插件入口）
+│   ├── package.json                 #   含 dsh.bundle 块（bundle manifest）
+│   └── index.ts                     #   cordis apply(ctx) + defineTool ×39
 │
 ├── tools/                           # 共享 Python CLI 工具（12 个脚本）
 │   ├── stock_data.py                #   行情 / 资金流 / 新闻 / 财务
@@ -414,11 +430,11 @@ stock-analysis/
 用户 (自然语言)
     │
     ▼
-Agent (Pi / Hermes / OpenClaw)
+Agent (Pi / Hermes / OpenClaw / dsh)
     │
     ├── 加载 SKILL.md → 分析框架 / 流程指引
     │
-    ├── 调用工具 → pi/index.ts 或 hermes/tools.py 或 openclaw/index.ts → python3 tools/xxx.py → JSON
+    ├── 调用工具 → pi/index.ts 或 hermes/tools.py 或 openclaw/index.ts 或 dsh/index.ts → python3 tools/xxx.py → JSON
     │
     ▼
 Agent (LLM 分析 + 生成报告)

--- a/dsh/README.md
+++ b/dsh/README.md
@@ -1,0 +1,89 @@
+# Stock Analysis — DeepSeek Harness (dsh) Plugin
+
+A股 / 港股 / 美股 / 日股 / 韩股 / 台股 行情、技术分析、筛选与回测。作为 dsh bundle 安装到 profile 后，对话中可调用 39 个工具，并自动注册 20 个工作流/策略方法论 skill。
+
+## 安装
+
+```bash
+dsh plugin --profile <你的profile> add @weaxs/dsh-stock-analysis
+dsh --profile <你的profile>
+```
+
+`dsh plugin add` 是 pnpm 的薄封装：安装后 dsh 会读取本包 `package.json` 里的 `dsh.bundle.patch`，把 `cordis.patch.yml` 作为一层叠加进 profile 组合。可用 `dsh --profile <你的profile> --dump-config` 验证 layer 已生效。
+
+从源码安装（本仓库根目录）：
+
+```bash
+npm install && npm run build:dsh
+dsh plugin --profile <你的profile> add ./dsh
+```
+
+### Python 运行时
+
+工具实际逻辑在 `tools/*.py`，依赖 `akshare`、`pandas`、`numpy`、`requests`。本包的 postinstall（`scripts/setup-python.mjs`）会在包目录下自动建 `.venv` 并装好依赖，前提：本机有 `python3 >= 3.9`。
+
+注意：dsh profile 使用 pnpm 且默认不执行第三方包的安装脚本。如 postinstall 被跳过，请在 profile 的 `pnpm-workspace.yaml` 中允许：
+
+```yaml
+allowBuilds:
+  "@weaxs/dsh-stock-analysis": true
+```
+
+如果 venv 最终没建起来，plugin 会回退到系统 `python3`（Windows 为 `python`），此时请自行 `pip install -r tools/requirements.txt`。
+
+## 工具列表
+
+### 行情数据
+- `get_kline` — K线 OHLCV（A/HK/US/JP/KR/TW）
+- `get_quote` — 实时报价
+- `get_capital_flow` — A股资金流（个股 / 多日 / 板块）
+- `get_news` — 财经新闻
+- `get_financials` — 关键财务指标
+
+### 分析
+- `get_technical_analysis` — MA/MACD/RSI/BOLL/KDJ + 综合评分
+- `analyze_pattern` — 12+ 种 K 线形态识别
+- `calculate_ma` — 独立均线计算
+- `get_volume_analysis` — 量价分析
+
+### 市场全景
+- `get_market_indices` — 主要指数（CN/HK/US/JP/KR/TW）
+- `get_sector_rankings` — A股板块涨跌幅排行
+- `get_market_stats` — A股大盘统计
+- `get_stock_info` — 股票基本信息
+- `get_chip_distribution` — A股筹码分布
+- `get_fundamental_context` — A股深度基本面
+- `detect_market_regime` — 市场阶段检测
+- `get_market_review` — 大盘日度复盘
+
+### 筛选与回测
+- `screen_stocks` — 全市场多因子筛选（AlphaSift L1）
+- `run_backtest` — 策略回测（AlphaEvo）
+- `evaluate_signal` — 信号历史准确率
+- `screen_risk` — 7维度风险筛查
+- `run_watchlist_analysis` — 自选股批量分析
+- `detect_anomaly` — 异动信号扫描
+
+### 报告与上下文
+- `render_stock_report` / `render_market_report` — 结构化 JSON → Markdown 报告
+- `build_watchlist_context` — 自选股上下文包
+- `analyze_position_context` — 持仓上下文分析
+- `check_alert_rules` — 无状态告警规则检查
+- `parse_stock_list` — 自选股/文本导入解析
+- `diagnose_data_sources` — 数据源链路诊断
+- `get_market_capabilities` — 市场能力边界
+
+### 工具类
+- `resolve_stock_name` — A股名称/拼音 → 代码
+- `check_trading_day` / `get_trading_days` — 交易日历
+
+### 情报搜索（需 API Key）
+- `search_stock_news` — Tavily/Brave/SerpAPI 新闻搜索
+- `search_comprehensive_intel` — 6 维度综合情报
+- `get_social_sentiment` — Reddit/X/Polymarket 情绪
+- `get_trending_sentiment` — 社交热门趋势
+- `extract_article` — 文章正文提取
+
+## 平行 Host
+
+同一份业务逻辑也以 [Pi Agent extension](../pi/index.ts)、[Hermes plugin](../hermes/) 和 [OpenClaw plugin](../openclaw/) 形式分发；选你用的那个生态即可。

--- a/dsh/cordis.patch.yml
+++ b/dsh/cordis.patch.yml
@@ -1,0 +1,6 @@
+# dsh bundle layer: inserts this package's plugin entry into the profile
+# composition. The entry module is resolved from the profile's node_modules
+# and must export the cordis function-plugin form (name/inject/apply).
+- insert:
+    - id: stock-analysis
+      name: "@weaxs/dsh-stock-analysis"

--- a/dsh/index.ts
+++ b/dsh/index.ts
@@ -1,0 +1,951 @@
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import * as cp from "node:child_process";
+import { promisify } from "node:util";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import type { Context } from "@deepseek-ai/cordis";
+import {
+  defineTool,
+  type InferArgs,
+  type ParameterSchemaSpec,
+} from "@deepseek-ai/dsh-tools";
+// Type-only import: pulls in the `Context.skills` service augmentation.
+import type {} from "@deepseek-ai/dsh-skill";
+import { venvPythonPath } from "../scripts/venv-python.mjs";
+
+// Indirected so tests can replace the executor without touching node:child_process.
+type Executor = (bin: string, argv: string[]) => Promise<string>;
+
+const defaultExecutor: Executor = async (bin, argv) => {
+  const exec = promisify(cp.execFile);
+  const { stdout } = await exec(bin, argv, { maxBuffer: 32 * 1024 * 1024 });
+  return stdout;
+};
+
+let executor: Executor = defaultExecutor;
+export function __setExecutor(fn: Executor) {
+  executor = fn;
+}
+
+const here = dirname(fileURLToPath(import.meta.url));
+// Published form: tools/ ships next to the package root (dist/../tools).
+// Dev form: tools/ is at the repo root.
+const toolsDir = existsSync(join(here, "tools"))
+  ? join(here, "tools")
+  : join(here, "..", "tools");
+const pkgRoot = dirname(toolsDir);
+const isWin = process.platform === "win32";
+
+function pythonBin(): string {
+  // Staged-payload layout: the venv may still live at the repo root one level up.
+  for (const root of [pkgRoot, join(pkgRoot, "..")]) {
+    const candidate = venvPythonPath(root);
+    if (existsSync(candidate)) return candidate;
+  }
+  // On Windows "python3" is usually the Microsoft Store stub — prefer "python".
+  return isWin ? "python" : "python3";
+}
+
+async function runPy(script: string, args: string[]): Promise<string> {
+  return executor(pythonBin(), [join(toolsDir, script), ...args]);
+}
+
+// One canonical stdout contract shared by every tool: execute returns the
+// CLI's raw JSON text (same relay shape as the pi/openclaw adapters), render
+// relays it to the model as a single text block.
+function pyTool<const S extends ParameterSchemaSpec>(opts: {
+  name: string;
+  description: string;
+  parameters: S;
+  script: string;
+  argv: (args: InferArgs<S>) => string[];
+}) {
+  return defineTool({
+    name: opts.name,
+    description: opts.description,
+    parameters: opts.parameters,
+    output: {
+      schema: { type: "string" },
+      render: (_args, value) => [{ type: "text", text: value }],
+    },
+    async execute(args) {
+      return runPy(opts.script, opts.argv(args));
+    },
+  });
+}
+
+// --- Skills ---------------------------------------------------------------
+
+// Published form: skills/ at the package root. Dev form: skills/ at repo root.
+const skillsDir = existsSync(join(here, "skills"))
+  ? join(here, "skills")
+  : join(here, "..", "skills");
+
+// Minimal single-line `key: value` read from the leading YAML frontmatter.
+function frontmatterValue(raw: string, key: string): string | undefined {
+  const block = raw.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+  const line = block?.[1].match(new RegExp(`^${key}:\\s*(.+)$`, "m"));
+  return line?.[1].trim();
+}
+
+// Hermes-style dynamic scan: every skills/<name>/SKILL.md becomes a registered
+// skill, so adding a skill directory needs no adapter edit.
+function registerSkills(ctx: Context) {
+  if (!existsSync(skillsDir)) return;
+  for (const child of readdirSync(skillsDir, { withFileTypes: true })) {
+    if (!child.isDirectory()) continue;
+    const skillFile = join(skillsDir, child.name, "SKILL.md");
+    if (!existsSync(skillFile)) continue;
+    const raw = readFileSync(skillFile, "utf-8");
+    ctx.skills.register({
+      name: child.name,
+      description: frontmatterValue(raw, "description") ?? child.name,
+      // The registry-facing body drops the frontmatter (metadata is carried by
+      // the explicit name/description fields above).
+      content: raw.replace(/^---\r?\n[\s\S]*?\r?\n---\r?\n?/, "").trimStart(),
+      source: "bundled",
+      path: skillFile,
+      resourceBase: { kind: "directory", path: join(skillsDir, child.name) },
+    });
+  }
+}
+
+// --- Plugin entry (cordis function-plugin form) ----------------------------
+
+export const name = "stock-analysis";
+export const inject = ["tools", "skills"];
+
+export function apply(ctx: Context) {
+  // --- Data Tools ---
+
+  ctx.tools.register(
+    pyTool({
+      name: "get_kline",
+      description:
+        "获取股票K线数据（OHLCV）。支持A股（如600519）、港股（如00700.HK）、美股（如AAPL）、日股（如7203.T）、韩股（如005930.KS）、台股（如2330.TW）及A股ETF",
+      parameters: {
+        symbol: {
+          type: "string",
+          required: true,
+          description:
+            "股票代码，如 600519（A股）、00700.HK（港股）、AAPL（美股）、7203.T（日股）、005930.KS（韩股）、2330.TW（台股）",
+        },
+        period: {
+          type: "string",
+          enum: ["daily", "weekly", "monthly"],
+          description: "K线周期，默认 daily",
+        },
+        count: { type: "number", description: "返回数据条数，默认 60" },
+      },
+      script: "stock_data.py",
+      argv: (p) => [
+        "kline",
+        p.symbol,
+        "--period",
+        p.period ?? "daily",
+        "--count",
+        String(p.count ?? 60),
+      ],
+    })
+  );
+
+  ctx.tools.register(
+    pyTool({
+      name: "get_quote",
+      description: "获取股票实时行情报价。支持A股、港股、美股、日股、韩股、台股",
+      parameters: {
+        symbol: { type: "string", required: true, description: "股票代码" },
+      },
+      script: "stock_data.py",
+      argv: (p) => ["quote", p.symbol],
+    })
+  );
+
+  ctx.tools.register(
+    pyTool({
+      name: "get_capital_flow",
+      description:
+        "获取A股资金流向数据。detail=个股每日明细，summary=多日汇总+趋势，sector_flow=板块资金流排行",
+      parameters: {
+        symbol: {
+          type: "string",
+          description: "A股股票代码（detail/summary模式必填），如 600519",
+        },
+        mode: {
+          type: "string",
+          enum: ["detail", "summary", "sector_flow"],
+          description: "模式：detail=每日明细（默认），summary=多日汇总，sector_flow=板块排行",
+        },
+      },
+      script: "stock_data.py",
+      argv: (p) => {
+        const args = ["capital_flow"];
+        if (p.symbol) args.push(p.symbol);
+        args.push("--mode", p.mode ?? "detail");
+        return args;
+      },
+    })
+  );
+
+  ctx.tools.register(
+    pyTool({
+      name: "get_news",
+      description: "获取股票相关财经新闻",
+      parameters: {
+        symbol: { type: "string", required: true, description: "股票代码" },
+        days: { type: "number", description: "获取最近几天的新闻，默认 3" },
+      },
+      script: "stock_data.py",
+      argv: (p) => ["news", p.symbol, "--days", String(p.days ?? 3)],
+    })
+  );
+
+  ctx.tools.register(
+    pyTool({
+      name: "get_financials",
+      description: "获取股票关键财务指标（PE/PB/市值/营收/净利润/ROE等）",
+      parameters: {
+        symbol: { type: "string", required: true, description: "股票代码" },
+      },
+      script: "stock_data.py",
+      argv: (p) => ["financials", p.symbol],
+    })
+  );
+
+  // --- Analysis Tools ---
+
+  ctx.tools.register(
+    pyTool({
+      name: "get_technical_analysis",
+      description:
+        "获取股票技术面分析（MA/MACD/RSI/BOLL/KDJ/成交量等指标 + 100分综合评分 + 6级买卖信号 + 趋势/偏离度/支撑压力位）",
+      parameters: {
+        symbol: { type: "string", required: true, description: "股票代码" },
+        period: {
+          type: "string",
+          enum: ["daily", "weekly", "monthly"],
+          description: "分析周期，默认 daily",
+        },
+        count: { type: "number", description: "用于计算指标的K线条数，默认 120" },
+      },
+      script: "technical.py",
+      argv: (p) => [
+        "analyze",
+        p.symbol,
+        "--period",
+        p.period ?? "daily",
+        "--count",
+        String(p.count ?? 120),
+      ],
+    })
+  );
+
+  ctx.tools.register(
+    pyTool({
+      name: "analyze_pattern",
+      description:
+        "K线形态识别 — 检测十字星、锤子线、吞没、启明星、黄昏星、双底、20日突破等12+种经典形态",
+      parameters: {
+        symbol: { type: "string", required: true, description: "股票代码" },
+        period: {
+          type: "string",
+          enum: ["daily", "weekly", "monthly"],
+          description: "K线周期，默认 daily",
+        },
+        days: { type: "number", description: "分析的K线天数，默认 60" },
+      },
+      script: "pattern.py",
+      argv: (p) => [
+        "analyze",
+        p.symbol,
+        "--period",
+        p.period ?? "daily",
+        "--days",
+        String(p.days ?? 60),
+      ],
+    })
+  );
+
+  // --- Market Tools ---
+
+  ctx.tools.register(
+    pyTool({
+      name: "get_market_indices",
+      description:
+        "获取主要市场指数行情。CN: 上证/深证/创业板/科创50/沪深300；HK: 恒生/国企/科技；US: 道琼斯/纳斯达克/标普500；JP: 日经225/东证；KR: KOSPI/KOSDAQ；TW: 台湾加权",
+      parameters: {
+        region: {
+          type: "string",
+          enum: ["cn", "hk", "us", "jp", "kr", "tw"],
+          description: "市场区域，默认 cn",
+        },
+      },
+      script: "stock_data.py",
+      argv: (p) => ["market_indices", "--region", p.region ?? "cn"],
+    })
+  );
+
+  ctx.tools.register(
+    pyTool({
+      name: "get_sector_rankings",
+      description:
+        "获取A股行业板块涨跌幅排行（含领涨股、涨跌家数等）。支持查看涨幅榜/跌幅榜/双向",
+      parameters: {
+        top: { type: "number", description: "返回排名前N的板块，默认 10" },
+        direction: {
+          type: "string",
+          enum: ["top", "bottom", "both"],
+          description: "top=涨幅榜（默认），bottom=跌幅榜，both=双向",
+        },
+      },
+      script: "stock_data.py",
+      argv: (p) => [
+        "sector_rankings",
+        "--top",
+        String(p.top ?? 10),
+        "--direction",
+        p.direction ?? "top",
+      ],
+    })
+  );
+
+  ctx.tools.register(
+    pyTool({
+      name: "get_stock_info",
+      description:
+        "获取股票基本信息（行业、板块、上市日期、总股本等）。A股返回板块/行业，其他市场返回行业/公司简介",
+      parameters: {
+        symbol: { type: "string", required: true, description: "股票代码" },
+      },
+      script: "stock_data.py",
+      argv: (p) => ["stock_info", p.symbol],
+    })
+  );
+
+  ctx.tools.register(
+    pyTool({
+      name: "get_chip_distribution",
+      description:
+        "获取A股筹码分布数据（获利比例、平均成本、90%/70%成本集中度）。仅支持A股",
+      parameters: {
+        symbol: {
+          type: "string",
+          required: true,
+          description: "A股股票代码，如 600519",
+        },
+      },
+      script: "stock_data.py",
+      argv: (p) => ["chip_distribution", p.symbol],
+    })
+  );
+
+  ctx.tools.register(
+    pyTool({
+      name: "get_market_stats",
+      description:
+        "获取A股市场整体统计（涨跌家数、涨停跌停数、平均涨幅、涨跌Top5、总成交额）",
+      parameters: {
+        market: {
+          type: "string",
+          enum: ["A"],
+          description: "市场，目前仅支持 A",
+        },
+      },
+      script: "stock_data.py",
+      argv: (p) => ["market_stats", "--market", p.market ?? "A"],
+    })
+  );
+
+  ctx.tools.register(
+    pyTool({
+      name: "get_fundamental_context",
+      description:
+        "获取A股深度基本面（估值PE/PB/PS + 成长性营收/净利增速 + 盈利能力ROE/毛利率 + 分红历史）",
+      parameters: {
+        symbol: {
+          type: "string",
+          required: true,
+          description: "A股股票代码，如 600519",
+        },
+      },
+      script: "stock_data.py",
+      argv: (p) => ["fundamental_context", p.symbol],
+    })
+  );
+
+  // --- Screener & Backtest ---
+
+  ctx.tools.register(
+    pyTool({
+      name: "screen_stocks",
+      description:
+        "全市场股票筛选（AlphaSift L1 多因子硬筛）。按PE/PB/市值/换手率/涨跌幅/量比等因子过滤和评分",
+      parameters: {
+        market: {
+          type: "string",
+          enum: ["A", "HK", "US"],
+          description: "市场，默认 A",
+        },
+        top: { type: "number", description: "返回排名前N的股票，默认 20" },
+        config: { type: "string", description: "自定义筛选配置YAML文件路径（可选）" },
+      },
+      script: "screener.py",
+      argv: (p) => {
+        const args = ["screen", "--market", p.market ?? "A", "--top", String(p.top ?? 20)];
+        if (p.config) args.push("--config", p.config);
+        return args;
+      },
+    })
+  );
+
+  ctx.tools.register(
+    pyTool({
+      name: "run_backtest",
+      description:
+        "策略回测（AlphaEvo）。读取YAML策略定义，在历史数据上模拟交易，输出收益率/回撤/胜率等指标",
+      parameters: {
+        strategy: { type: "string", required: true, description: "策略YAML文件路径" },
+        symbol: { type: "string", required: true, description: "股票代码" },
+        start: { type: "string", description: "回测起始日期，格式 YYYY-MM-DD" },
+        end: { type: "string", description: "回测结束日期，格式 YYYY-MM-DD" },
+        capital: { type: "number", description: "初始资金，默认 1000000" },
+      },
+      script: "backtest.py",
+      argv: (p) => {
+        const args = ["run", p.strategy, p.symbol];
+        if (p.start) args.push("--start", p.start);
+        if (p.end) args.push("--end", p.end);
+        args.push("--capital", String(p.capital ?? 1000000));
+        return args;
+      },
+    })
+  );
+
+  ctx.tools.register(
+    pyTool({
+      name: "evaluate_signal",
+      description:
+        "技术信号历史准确率评估 — 回溯历史数据，统计某个技术信号触发后N日的胜率和平均收益。支持9种信号：macd_golden_cross/macd_death_cross/rsi_oversold/rsi_overbought/breakout_20d/breakdown_20d/volume_surge/ma_golden_cross/ma_death_cross",
+      parameters: {
+        symbol: { type: "string", required: true, description: "股票代码" },
+        signal: {
+          type: "string",
+          required: true,
+          enum: [
+            "macd_golden_cross",
+            "macd_death_cross",
+            "rsi_oversold",
+            "rsi_overbought",
+            "breakout_20d",
+            "breakdown_20d",
+            "volume_surge",
+            "ma_golden_cross",
+            "ma_death_cross",
+          ],
+          description: "信号名称",
+        },
+        forward_days: {
+          type: "string",
+          description: "逗号分隔的前瞻天数，默认 3,5,10",
+        },
+        lookback: { type: "number", description: "回溯K线条数，默认 250（约1年）" },
+      },
+      script: "backtest.py",
+      argv: (p) => [
+        "evaluate_signal",
+        p.symbol,
+        p.signal,
+        "--forward",
+        p.forward_days ?? "3,5,10",
+        "--lookback",
+        String(p.lookback ?? 250),
+      ],
+    })
+  );
+
+  // --- Name Resolution ---
+
+  ctx.tools.register(
+    pyTool({
+      name: "resolve_stock_name",
+      description:
+        "股票名称智能解析 — 输入中文名（贵州茅台）、拼音（guizhou maotai/gzmt）、部分代码，返回匹配的股票代码。仅支持A股",
+      parameters: {
+        query: {
+          type: "string",
+          required: true,
+          description: "股票名称、拼音、拼音首字母或部分代码",
+        },
+        top: { type: "number", description: "返回匹配数量，默认 5" },
+      },
+      script: "name_resolver.py",
+      argv: (p) => ["resolve", p.query, "--top", String(p.top ?? 5)],
+    })
+  );
+
+  // --- Trading Calendar ---
+
+  ctx.tools.register(
+    pyTool({
+      name: "check_trading_day",
+      description:
+        "查询某日是否为交易日。支持CN（A股）、HK（港股）、US（美股）、JP（日股）、KR（韩股）、TW（台股）",
+      parameters: {
+        market: {
+          type: "string",
+          required: true,
+          enum: ["CN", "HK", "US", "JP", "KR", "TW"],
+          description: "市场",
+        },
+        date: { type: "string", description: "日期（YYYY-MM-DD），不填则查今天" },
+      },
+      script: "trading_calendar.py",
+      argv: (p) => {
+        const args = ["check", p.market];
+        if (p.date) args.push("--date", p.date);
+        return args;
+      },
+    })
+  );
+
+  ctx.tools.register(
+    pyTool({
+      name: "get_trading_days",
+      description: "获取最近/未来N个交易日列表。支持CN/HK/US/JP/KR/TW",
+      parameters: {
+        market: {
+          type: "string",
+          required: true,
+          enum: ["CN", "HK", "US", "JP", "KR", "TW"],
+          description: "市场",
+        },
+        direction: {
+          type: "string",
+          enum: ["next", "prev"],
+          description: "next=未来交易日, prev=过去交易日",
+        },
+        count: { type: "number", description: "返回天数，默认 5" },
+        date: { type: "string", description: "起始日期（YYYY-MM-DD），默认今天" },
+      },
+      script: "trading_calendar.py",
+      argv: (p) => {
+        const args = [p.direction ?? "next", p.market, "--count", String(p.count ?? 5)];
+        if (p.date) args.push("--date", p.date);
+        return args;
+      },
+    })
+  );
+
+  // --- Standalone MA Calculator ---
+
+  ctx.tools.register(
+    pyTool({
+      name: "calculate_ma",
+      description:
+        "独立均线计算器 — 支持任意周期MA（5/10/20/30/60/120/250或自定义）+ 偏离度 + 均线排列 + 金叉死叉检测",
+      parameters: {
+        symbol: { type: "string", required: true, description: "股票代码" },
+        periods: {
+          type: "string",
+          description: "逗号分隔的MA周期列表，如 5,10,20,60,120,250",
+        },
+        kline_period: {
+          type: "string",
+          enum: ["daily", "weekly", "monthly"],
+          description: "K线周期，默认 daily",
+        },
+      },
+      script: "technical.py",
+      argv: (p) => [
+        "calculate_ma",
+        p.symbol,
+        "--periods",
+        p.periods ?? "5,10,20,30,60,120,250",
+        "--period",
+        p.kline_period ?? "daily",
+        "--count",
+        "300",
+      ],
+    })
+  );
+
+  // --- Volume-Price Analysis ---
+
+  ctx.tools.register(
+    pyTool({
+      name: "get_volume_analysis",
+      description:
+        "独立量价分析 — 量价相关性、上涨/下跌日成交量对比、量能趋势、量价模式解读（放量上涨/缩量回调等）",
+      parameters: {
+        symbol: { type: "string", required: true, description: "股票代码" },
+        period: {
+          type: "string",
+          enum: ["daily", "weekly", "monthly"],
+          description: "K线周期，默认 daily",
+        },
+        count: { type: "number", description: "分析K线条数，默认 60" },
+      },
+      script: "volume_analysis.py",
+      argv: (p) => [
+        "analyze",
+        p.symbol,
+        "--period",
+        p.period ?? "daily",
+        "--count",
+        String(p.count ?? 60),
+      ],
+    })
+  );
+
+  // --- Search Intelligence ---
+
+  ctx.tools.register(
+    pyTool({
+      name: "search_stock_news",
+      description:
+        "多引擎股票新闻搜索（支持 Tavily/Brave/SerpAPI）。需配置对应 API Key 环境变量",
+      parameters: {
+        query: { type: "string", required: true, description: "搜索关键词" },
+        count: { type: "number", description: "返回结果数量，默认 10" },
+      },
+      script: "search_intel.py",
+      argv: (p) => ["search", p.query, "--count", String(p.count ?? 10)],
+    })
+  );
+
+  ctx.tools.register(
+    pyTool({
+      name: "search_comprehensive_intel",
+      description:
+        "股票综合情报搜索 — 从6个维度（新闻/公告/行情分析/风险/业绩/行业）搜索综合信息",
+      parameters: {
+        symbol: { type: "string", required: true, description: "股票代码" },
+        name: { type: "string", description: "股票名称（可选，提升搜索准确度）" },
+      },
+      script: "search_intel.py",
+      argv: (p) => {
+        const args = ["comprehensive", p.symbol];
+        if (p.name) args.push("--name", p.name);
+        return args;
+      },
+    })
+  );
+
+  ctx.tools.register(
+    pyTool({
+      name: "get_social_sentiment",
+      description:
+        "获取股票社交媒体情绪数据（Reddit/X/Polymarket）。主要支持美股。需配置 SENTIMENT_API_KEY",
+      parameters: {
+        symbol: { type: "string", required: true, description: "股票代码（如 AAPL）" },
+      },
+      script: "search_intel.py",
+      argv: (p) => ["sentiment", p.symbol],
+    })
+  );
+
+  ctx.tools.register(
+    pyTool({
+      name: "get_trending_sentiment",
+      description:
+        "获取社交媒体热门趋势（Reddit/X/Polymarket热门股票讨论）。数据缓存10分钟。适用于发现市场热点",
+      parameters: {},
+      script: "search_intel.py",
+      argv: () => ["trending"],
+    })
+  );
+
+  ctx.tools.register(
+    pyTool({
+      name: "extract_article",
+      description:
+        "网页文章全文提取 — 输入URL，提取文章标题、正文（最多3000字）、作者、发布日期等。适用于深度阅读搜索结果中的新闻/研报",
+      parameters: {
+        url: { type: "string", required: true, description: "文章URL" },
+      },
+      script: "search_intel.py",
+      argv: (p) => ["extract", p.url],
+    })
+  );
+
+  ctx.tools.register(
+    pyTool({
+      name: "screen_risk",
+      description:
+        "风险专项筛查 — 7维度风险检测（估值极端/技术预警/解禁到期/内部人减持/业绩预警/监管处罚/行业政策），返回风险评级和一票否决标记",
+      parameters: {
+        symbol: {
+          type: "string",
+          required: true,
+          description: "股票代码（如 600519）",
+        },
+        name: { type: "string", description: "股票名称（可选，提升新闻搜索准确度）" },
+      },
+      script: "risk_screening.py",
+      argv: (p) => {
+        const args = ["screen", p.symbol];
+        if (p.name) args.push("--name", p.name);
+        return args;
+      },
+    })
+  );
+
+  ctx.tools.register(
+    pyTool({
+      name: "detect_market_regime",
+      description:
+        "市场状态检测 — 分析大盘指数判断当前市场阶段（上涨趋势/下跌趋势/横盘震荡/高波动/板块热点），并推荐适合的分析策略",
+      parameters: {
+        market: {
+          type: "string",
+          enum: ["A", "HK", "US"],
+          description: "市场代码，默认 A",
+        },
+      },
+      script: "market_regime.py",
+      argv: (p) => ["detect", p.market ?? "A"],
+    })
+  );
+
+  ctx.tools.register(
+    pyTool({
+      name: "get_market_review",
+      description:
+        "大盘复盘 — 获取市场日度复盘数据，包含指数、涨跌统计、板块排名、新闻、市场温度与策略建议",
+      parameters: {
+        market: {
+          type: "string",
+          enum: ["A", "HK", "US", "all"],
+          description: "市场代码，默认 A。all 表示所有市场",
+        },
+      },
+      script: "market_review.py",
+      argv: (p) => ["review", "--market", p.market ?? "A"],
+    })
+  );
+
+  ctx.tools.register(
+    pyTool({
+      name: "run_watchlist_analysis",
+      description:
+        "批量自选股分析 — 对多只股票并行采集行情/技术/资金/风险等数据，返回汇总结果。适用于每日定时分析自选股列表",
+      parameters: {
+        symbols: {
+          type: "string",
+          required: true,
+          description: "逗号分隔的股票代码列表，如 600519,000001,300750",
+        },
+        workers: {
+          type: "number",
+          description: "并发数，默认 3（建议不超过5，避免API限流）",
+        },
+      },
+      script: "watchlist.py",
+      argv: (p) => ["analyze", p.symbols, "--workers", String(p.workers ?? 3)],
+    })
+  );
+
+  ctx.tools.register(
+    pyTool({
+      name: "detect_anomaly",
+      description:
+        "异常/事件检测 — 一键扫描股票当前所有异动信号（MACD金叉死叉、RSI超买超卖、20日突破、放量异动、涨跌停、布林突破、KDJ极值、资金异动等），返回结构化异常列表",
+      parameters: {
+        symbol: {
+          type: "string",
+          required: true,
+          description: "股票代码（如 600519、AAPL、00700.HK）",
+        },
+      },
+      script: "anomaly_detect.py",
+      argv: (p) => ["detect", p.symbol],
+    })
+  );
+
+  // --- Diagnostics & Capabilities ---
+
+  ctx.tools.register(
+    pyTool({
+      name: "diagnose_data_sources",
+      description:
+        "数据源诊断 — 检查当前环境可用的数据 provider（akshare/tushare/yfinance/finnhub/longbridge/alphavantage），输出每个市场的可用链路、缺失 env、warnings",
+      parameters: {
+        market: {
+          type: "string",
+          enum: ["A", "HK", "US", "JP", "KR", "TW", "all"],
+          description: "市场，默认 all",
+        },
+      },
+      script: "diagnostics.py",
+      argv: (p) => ["check", "--market", p.market ?? "all"],
+    })
+  );
+
+  ctx.tools.register(
+    pyTool({
+      name: "get_market_capabilities",
+      description:
+        "市场能力边界 — 返回指定市场支持/不支持的工具列表，避免 agent 对港股调 get_chip_distribution 或对美股调 get_capital_flow 后编造数据",
+      parameters: {
+        market: {
+          type: "string",
+          enum: ["A", "HK", "US", "JP", "KR", "TW"],
+          description: "市场代码",
+        },
+        symbol: { type: "string", description: "股票代码（自动识别市场，与 market 二选一）" },
+      },
+      script: "capabilities.py",
+      argv: (p) =>
+        p.symbol
+          ? ["get", "--symbol", p.symbol]
+          : ["get", "--market", p.market ?? "A"],
+    })
+  );
+
+  // --- Report Rendering ---
+
+  ctx.tools.register(
+    pyTool({
+      name: "render_stock_report",
+      description:
+        "股票分析报告渲染 — 将结构化 JSON（符合 schemas/report_schema.json）通过 j2 模板渲染为 Markdown。template: brief|full。仅渲染，不保存不推送",
+      parameters: {
+        report: {
+          type: "object",
+          additionalProperties: true,
+          required: true,
+          description: "结构化股票报告",
+        },
+        template: {
+          type: "string",
+          enum: ["brief", "full"],
+          description: "模板类型，默认 full",
+        },
+      },
+      script: "report_renderer.py",
+      argv: (p) => {
+        const b64 = Buffer.from(JSON.stringify(p.report), "utf-8").toString("base64");
+        return ["stock", "--template", p.template ?? "full", "--input-b64", b64];
+      },
+    })
+  );
+
+  ctx.tools.register(
+    pyTool({
+      name: "render_market_report",
+      description:
+        "大盘复盘报告渲染 — 将结构化 JSON（符合 schemas/market_review_schema.json）通过 j2 模板渲染为 Markdown",
+      parameters: {
+        report: {
+          type: "object",
+          additionalProperties: true,
+          required: true,
+          description: "结构化市场复盘",
+        },
+        template: {
+          type: "string",
+          enum: ["full"],
+          description: "模板类型，默认 full",
+        },
+      },
+      script: "report_renderer.py",
+      argv: (p) => {
+        const b64 = Buffer.from(JSON.stringify(p.report), "utf-8").toString("base64");
+        return ["market", "--template", p.template ?? "full", "--input-b64", b64];
+      },
+    })
+  );
+
+  // --- Watchlist / Position / Alert Context ---
+
+  ctx.tools.register(
+    pyTool({
+      name: "build_watchlist_context",
+      description:
+        "自选股上下文包 — 对多只股票输出评分/趋势/异常/风险/建议 next_tools 的 agent 友好摘要。宿主 agent 决定如何写日报或深入分析",
+      parameters: {
+        symbols: { type: "string", required: true, description: "逗号分隔的股票代码列表" },
+        include_market_review: {
+          type: "boolean",
+          description: "是否附带各市场复盘，默认 false",
+        },
+        workers: { type: "number", description: "并发数，默认 3" },
+      },
+      script: "watchlist_context.py",
+      argv: (p) => {
+        const args = ["build", p.symbols, "--workers", String(p.workers ?? 3)];
+        if (p.include_market_review) args.push("--include-market-review");
+        return args;
+      },
+    })
+  );
+
+  ctx.tools.register(
+    pyTool({
+      name: "analyze_position_context",
+      description:
+        "持仓上下文分析 — 输入成本/仓位/止损止盈，结合现价和技术位输出浮盈亏、离止损距离、风险级别、操作建议。无状态、不存账户",
+      parameters: {
+        symbol: { type: "string", required: true, description: "股票代码" },
+        cost: { type: "number", required: true, description: "成本价" },
+        quantity: { type: "number", required: true, description: "持仓数量" },
+        stop_loss: { type: "number", description: "止损价" },
+        take_profit: { type: "number", description: "止盈价" },
+      },
+      script: "position_context.py",
+      argv: (p) => {
+        const args = [
+          "analyze",
+          p.symbol,
+          "--cost",
+          String(p.cost),
+          "--quantity",
+          String(p.quantity),
+        ];
+        if (p.stop_loss !== undefined) args.push("--stop-loss", String(p.stop_loss));
+        if (p.take_profit !== undefined) args.push("--take-profit", String(p.take_profit));
+        return args;
+      },
+    })
+  );
+
+  ctx.tools.register(
+    pyTool({
+      name: "check_alert_rules",
+      description:
+        "无状态告警规则检查 — 传入规则数组，返回当前是否触发。规则类型：price_below/price_above/change_pct_above/change_pct_below/volume_ratio_above/anomaly/risk_veto/risk_level_at_least。不做调度不存历史",
+      parameters: {
+        symbol: { type: "string", required: true, description: "股票代码" },
+        rules: {
+          type: "array",
+          items: { type: "object", additionalProperties: true },
+          required: true,
+          description: "规则列表，每项 { type, value }",
+        },
+      },
+      script: "alert_rules.py",
+      argv: (p) => {
+        const b64 = Buffer.from(JSON.stringify(p.rules), "utf-8").toString("base64");
+        return ["check", p.symbol, "--rules-b64", b64];
+      },
+    })
+  );
+
+  ctx.tools.register(
+    pyTool({
+      name: "parse_stock_list",
+      description:
+        "自选股/文本导入解析 — 从自然语言、CSV、Markdown 表格提取股票，自动识别 A 股 6 位代码、港股 xxxxx.HK、美股 ticker、日股 xxxx.T、韩股 xxxxxx.KS/KQ、台股 xxxx.TW，并调用 name_resolver 处理中文股票名",
+      parameters: {
+        text: { type: "string", required: true, description: "待解析的文本" },
+      },
+      script: "import_parser.py",
+      argv: (p) => {
+        const b64 = Buffer.from(String(p.text), "utf-8").toString("base64");
+        return ["parse", "--text-b64", b64];
+      },
+    })
+  );
+
+  registerSkills(ctx);
+}

--- a/dsh/package.json
+++ b/dsh/package.json
@@ -1,0 +1,51 @@
+{
+  "name": "@weaxs/dsh-stock-analysis",
+  "version": "0.1.4",
+  "description": "DeepSeek Harness (dsh) plugin for stock analysis, screening, and strategy backtesting across A/HK/US/JP/KR/TW markets",
+  "type": "module",
+  "main": "./dist/index.js",
+  "exports": {
+    ".": "./dist/index.js",
+    "./cordis.patch.yml": "./cordis.patch.yml"
+  },
+  "dsh": {
+    "bundle": {
+      "patch": "./cordis.patch.yml"
+    }
+  },
+  "scripts": {
+    "postinstall": "node scripts/setup-python.mjs"
+  },
+  "files": [
+    "dist/",
+    "cordis.patch.yml",
+    "README.md",
+    "tools/",
+    "skills/",
+    "schemas/",
+    "templates/",
+    "strategies/",
+    "scripts/"
+  ],
+  "keywords": [
+    "dsh",
+    "dsh-plugin",
+    "deepseek-harness",
+    "stock-analysis",
+    "stock-screener",
+    "backtest",
+    "a-shares",
+    "hk-stocks",
+    "us-stocks"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Weaxs/stock-analysis-plugin"
+  },
+  "license": "MIT",
+  "peerDependencies": {
+    "@deepseek-ai/cordis": "^4.0.1",
+    "@deepseek-ai/dsh-skill": "^0.0.1-rc.1",
+    "@deepseek-ai/dsh-tools": "^0.0.1-rc.1"
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,9 @@
       "hasInstallScript": true,
       "license": "MIT",
       "devDependencies": {
+        "@deepseek-ai/cordis": "^4.0.1",
+        "@deepseek-ai/dsh-skill": "^0.0.1-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.0.1-rc.1",
         "@types/node": "^22.0.0",
         "esbuild": "^0.28.0",
         "jiti": "^2.7.0",
@@ -17,6 +20,264 @@
         "tsx": "^4.22.1",
         "typebox": "^1.3.10",
         "typescript": "^5.5.0"
+      }
+    },
+    "node_modules/@deepseek-ai/cordis": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/cordis/-/cordis-4.0.1.tgz",
+      "integrity": "sha512-YBdskTU2Po1kru3GgcUWUbkTsPMA9LkSQDAY8rBkFJeajdgcQad3QPJZE26JyK99Xb6HaASvoXg2DSUTeN/0Nw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@deepseek-ai/cosmokit": "^1.8.2",
+        "@standard-schema/spec": "^1.1.0"
+      },
+      "bin": {
+        "cordis": "bin.js"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis-plugin-include": "^1.0.6",
+        "@deepseek-ai/cordis-plugin-loader": "^1.0.2"
+      },
+      "peerDependenciesMeta": {
+        "@deepseek-ai/cordis-plugin-include": {
+          "optional": true
+        },
+        "@deepseek-ai/cordis-plugin-loader": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@deepseek-ai/cosmokit": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/cosmokit/-/cosmokit-1.8.2.tgz",
+      "integrity": "sha512-muBOKtSrUKU5m/xpq8ZXWL6hQ/jgd4PhU2PqH97bcxIiLEJfNwZOGQEx4t/aS/GgxRAR+ra9pMHPMtTHU4sqqA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@deepseek-ai/dsh-agent": {
+      "version": "0.0.1-rc.5",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-agent/-/dsh-agent-0.0.1-rc.5.tgz",
+      "integrity": "sha512-eJoG89GRf8d7SCjGiSsC5g0fPijuNnJWIis5MmzIRoPSEv73PFOYs+EBHDEpPCQkFNmQjYtviiFhbhNPg9+3CQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.1-rc.4",
+        "@deepseek-ai/dsh-invariants": "^0.0.1-rc.5",
+        "@deepseek-ai/dsh-llm": "^0.0.1-rc.5",
+        "@deepseek-ai/dsh-scope": "^0.0.1-rc.5",
+        "@deepseek-ai/dsh-session": "^0.0.1-rc.5",
+        "@deepseek-ai/dsh-system-prompt": "^0.0.1-rc.5",
+        "@deepseek-ai/dsh-typert-protocol": "^0.0.1-rc.5"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-attachment": {
+      "version": "0.0.1-rc.5",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-attachment/-/dsh-attachment-0.0.1-rc.5.tgz",
+      "integrity": "sha512-mjv3gtW39nFJX0MQHZlW9PBlZVLDUZ5HqCfr2gr+ypPQ86RNtHzmLI/9XHF0xcMkT8VMCs6x53bipi87BEQMCg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.1-rc.4",
+        "@deepseek-ai/dsh-brand": "^0.0.1-rc.5",
+        "@deepseek-ai/dsh-invariants": "^0.0.1-rc.5"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-brand": {
+      "version": "0.0.1-rc.5",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-brand/-/dsh-brand-0.0.1-rc.5.tgz",
+      "integrity": "sha512-aVHMvG5hYLYIXUsvf9mfi0Fvr8w3oU6y1qbhiOiWUVSQu2pKkFgiKJGPIHhMLoj0q4IkewNvsVFQeECdsLLXYg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.1-rc.4",
+        "@deepseek-ai/dsh-invariants": "^0.0.1-rc.5"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-code-runtime": {
+      "version": "0.0.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-code-runtime/-/dsh-code-runtime-0.0.1-rc.1.tgz",
+      "integrity": "sha512-lfHc2HevlivlnKWt876s1rOSov5PyR9tPpPiQFEs46jREF5JjwMdE8yTUbpEnBt9A97NZ+vKl2o7LbqVZPSSxg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.0.1-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-invariants": {
+      "version": "0.0.1-rc.5",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-invariants/-/dsh-invariants-0.0.1-rc.5.tgz",
+      "integrity": "sha512-63LTrIMPAeJowv5E9Sr87w1SPs1Ign2/ofr+LPdrgAi4Pi32YFK9o4vSVv7osRHAIzlwxRCoFksythq+Jire3w==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.1-rc.4"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.1-rc.4"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-llm": {
+      "version": "0.0.1-rc.5",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-llm/-/dsh-llm-0.0.1-rc.5.tgz",
+      "integrity": "sha512-+w+bYuimnZZwQshdEkZynFPH9FwYfRrEDkgnBshfkjDe1nqqH3h/K6amu8pcIZ2J8XaI6osAImyz7BAAuN589g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.1-rc.4"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.1-rc.4",
+        "@deepseek-ai/dsh-attachment": "^0.0.1-rc.5",
+        "@deepseek-ai/dsh-brand": "^0.0.1-rc.5",
+        "@deepseek-ai/dsh-invariants": "^0.0.1-rc.5",
+        "@deepseek-ai/dsh-timeout": "^0.0.1-rc.5"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-scope": {
+      "version": "0.0.1-rc.5",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-scope/-/dsh-scope-0.0.1-rc.5.tgz",
+      "integrity": "sha512-9dPbw8Lj2VMmbFqUKMlzhudSN/Z5xVY6otDMSKBqnF88WnOugslZXkYToOMQO8EUEJorE0d0M+aUAq4titzOwA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.1-rc.4",
+        "@deepseek-ai/dsh-invariants": "^0.0.1-rc.5"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-session": {
+      "version": "0.0.1-rc.5",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session/-/dsh-session-0.0.1-rc.5.tgz",
+      "integrity": "sha512-/xFNk3scb0KXGKW9vjpW4drNTHVJYEw5gdW8xOPbgO+8/4AEtrS2m69P5ancdgcpufheLgJQ1H6sacFUAP1IpQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.1-rc.4",
+        "@deepseek-ai/dsh-brand": "^0.0.1-rc.5",
+        "@deepseek-ai/dsh-invariants": "^0.0.1-rc.5",
+        "@deepseek-ai/dsh-llm": "^0.0.1-rc.5",
+        "@deepseek-ai/dsh-scope": "^0.0.1-rc.5",
+        "@deepseek-ai/dsh-typert-protocol": "^0.0.1-rc.5"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-skill": {
+      "version": "0.0.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-skill/-/dsh-skill-0.0.1-rc.1.tgz",
+      "integrity": "sha512-YFBnqfZqBbid9iZpopgtXhbPzWOroj2s/DldaJ1xTWpQVyVVT2UOTDFRgxVAHkuZJMy79iv0a8br3Hu+3Gcl0Q==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.1-rc.1"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.0.1-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.0.1-rc.1",
+        "@deepseek-ai/dsh-scope": "^0.0.1-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-system-prompt": {
+      "version": "0.0.1-rc.5",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-system-prompt/-/dsh-system-prompt-0.0.1-rc.5.tgz",
+      "integrity": "sha512-IMB3dT8ErPWq15tIXdItQ+OOzHKYdLGl6vwNkeZf2n3hlw0bxDzj1AmLCgE4vDByDue9BQTWl4cMfNN0NxVMfA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.1-rc.4"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.1-rc.4",
+        "@deepseek-ai/dsh-invariants": "^0.0.1-rc.5",
+        "@deepseek-ai/dsh-llm": "^0.0.1-rc.5",
+        "@deepseek-ai/dsh-scope": "^0.0.1-rc.5"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-timeout": {
+      "version": "0.0.1-rc.5",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-timeout/-/dsh-timeout-0.0.1-rc.5.tgz",
+      "integrity": "sha512-SxuBtgHCQx5bOqua/U/5H2jMio8w1SXpjcDqmd0WBZ7OvmgnLovvbmCrEQeH0jtbkqL25yEZ/dDCr6cE27Pi5Q==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.1-rc.4",
+        "@deepseek-ai/dsh-invariants": "^0.0.1-rc.5"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-tools": {
+      "version": "0.0.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tools/-/dsh-tools-0.0.1-rc.1.tgz",
+      "integrity": "sha512-mrtq+UXc6UVidrGo4GM8RAH0Gqc4iFOmtPeQAz59Phhjl3EmzkFI0Mo6dQlHQamrc2J9jppPtGtUzW9qHmwxDQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.1-rc.1"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.1-rc.1",
+        "@deepseek-ai/dsh-agent": "^0.0.1-rc.1",
+        "@deepseek-ai/dsh-code-runtime": "^0.0.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.0.1-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.0.1-rc.1",
+        "@deepseek-ai/dsh-scope": "^0.0.1-rc.1",
+        "@deepseek-ai/dsh-session": "^0.0.1-rc.1",
+        "@deepseek-ai/dsh-system-prompt": "^0.0.1-rc.1",
+        "@deepseek-ai/dsh-user-approval": "^0.0.1-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-typert-protocol": {
+      "version": "0.0.1-rc.5",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-typert-protocol/-/dsh-typert-protocol-0.0.1-rc.5.tgz",
+      "integrity": "sha512-8ierrjmlloXATrJHeIE6EeItOT0M1kPmk+MTvV4600CD1XuAigVpktYc4HsbXw5jaKzt/jQK4eRCARYWeuvwhw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.1-rc.4",
+        "@deepseek-ai/dsh-invariants": "^0.0.1-rc.5"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-user-approval": {
+      "version": "0.0.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-user-approval/-/dsh-user-approval-0.0.1-rc.1.tgz",
+      "integrity": "sha512-28J7iT2fl9I0haeCRwVIWqhFBO3xG+A1GAdfhLJG/9YkB0F3Cs6FUoRtNQ7pjxkJ6QzELY/gRBE7axCP0ETHcA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.1-rc.1"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.1-rc.1",
+        "@deepseek-ai/dsh-agent": "^0.0.1-rc.1",
+        "@deepseek-ai/dsh-brand": "^0.0.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.0.1-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.0.1-rc.1",
+        "@deepseek-ai/dsh-scope": "^0.0.1-rc.1",
+        "@deepseek-ai/dsh-session": "^0.0.1-rc.1",
+        "@deepseek-ai/dsh-system-prompt": "^0.0.1-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/schemastery": {
+      "version": "3.18.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/schemastery/-/schemastery-3.18.1.tgz",
+      "integrity": "sha512-Qn0FCSwCQnpnj6SB31I6i2sIKgKWnkbJM8O0EU91Gv2UsYVvtZTl6IA0sCwk2e2MZf5S8w5hpq9QkeVvK9qwxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/cosmokit": "^1.8.2",
+        "@standard-schema/spec": "^1.1.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -460,6 +721,13 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/node": {
       "version": "22.19.19",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,8 @@
   ],
   "scripts": {
     "postinstall": "node scripts/setup-python.mjs",
-    "build:openclaw": "esbuild openclaw/index.ts --bundle --format=esm --platform=node --external:openclaw/* --outfile=openclaw/dist/index.js"
+    "build:openclaw": "esbuild openclaw/index.ts --bundle --format=esm --platform=node --external:openclaw/* --outfile=openclaw/dist/index.js",
+    "build:dsh": "esbuild dsh/index.ts --bundle --format=esm --platform=node --external:@deepseek-ai/* --outfile=dsh/dist/index.js"
   },
   "keywords": [
     "pi-agent",
@@ -73,6 +74,9 @@
   },
   "license": "MIT",
   "devDependencies": {
+    "@deepseek-ai/cordis": "^4.0.1",
+    "@deepseek-ai/dsh-skill": "^0.0.1-rc.1",
+    "@deepseek-ai/dsh-tools": "^0.0.1-rc.1",
     "@types/node": "^22.0.0",
     "esbuild": "^0.28.0",
     "jiti": "^2.7.0",

--- a/scripts/sync-version.sh
+++ b/scripts/sync-version.sh
@@ -10,6 +10,7 @@
 #   - package.json            (npm root package)
 #   - package-lock.json       (kept in lockstep so `npm publish` doesn't warn)
 #   - openclaw/package.json   (OpenClaw npm package version)
+#   - dsh/package.json        (dsh npm package version)
 #
 # Idempotent: running twice with the same tag is a no-op.
 set -euo pipefail
@@ -42,10 +43,10 @@ p.write_text(new)
 print(f"  pyproject.toml: {n} substitution(s)")
 PY
 
-# npm root and openclaw sub-package
+# npm root and host sub-packages
 # `npm version` refuses in a workspace unless we bypass with --no-git-tag-version
 # --allow-same-version keeps it idempotent when the tag already matches.
-for dir in "." "openclaw"; do
+for dir in "." "openclaw" "dsh"; do
   if [[ -f "$dir/package.json" ]]; then
     (cd "$dir" && npm version "$VERSION" --no-git-tag-version --allow-same-version) >/dev/null
     echo "  $dir/package.json: bumped"

--- a/tests/_stubs/dsh-tools.ts
+++ b/tests/_stubs/dsh-tools.ts
@@ -1,0 +1,5 @@
+// Stub for @deepseek-ai/dsh-tools — used in tests via jiti alias.
+// defineTool is the identity function: the captured options object IS the
+// definition handed to ctx.tools.register, so tests can inspect name,
+// parameters, output.render, and invoke execute() directly.
+export const defineTool = (opts: unknown) => opts;

--- a/tests/e2e/dsh_tool_spy.mjs
+++ b/tests/e2e/dsh_tool_spy.mjs
@@ -1,0 +1,17 @@
+// dsh tool-call spy for the real-host smoke (tests/e2e/host_smoke.mjs dsh).
+// Inserted into the headless profile via a --patch overlay; logs the name of
+// every executed tool, one per line, to config.logFile. The smoke reads that
+// file to prove our tools were actually invoked — dsh's durable session log
+// only carries the session header in one-shot runs, so it can't serve as the
+// tool-call trace.
+import { appendFileSync } from "node:fs";
+
+export const name = "smoke-tool-spy";
+export const inject = ["tools"];
+
+export function apply(ctx, config) {
+  // Emit-mode event fired once per settled tool dispatch.
+  ctx.on("tools/result", (exec) => {
+    appendFileSync(config.logFile, `${exec.name}\n`);
+  });
+}

--- a/tests/e2e/host_smoke.mjs
+++ b/tests/e2e/host_smoke.mjs
@@ -3,7 +3,7 @@
  * Real-host smoke QA: install the plugin into a real host runtime and run one
  * QA turn through the host's own agent loop.
  *
- * Usage: node tests/e2e/host_smoke.mjs <pi|openclaw|hermes>
+ * Usage: node tests/e2e/host_smoke.mjs <pi|openclaw|hermes|dsh>
  *
  * Env:
  *   SMOKE_LLM_API_KEY  (required) API key for the QA model
@@ -21,13 +21,14 @@ import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { promisify } from "node:util";
+import { zstdDecompressSync } from "node:zlib";
 
 const execFileAsync = promisify(execFile);
 const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..");
 
 const host = process.argv[2];
-if (!["pi", "openclaw", "hermes"].includes(host)) {
-  console.error("usage: host_smoke.mjs <pi|openclaw|hermes>");
+if (!["pi", "openclaw", "hermes", "dsh"].includes(host)) {
+  console.error("usage: host_smoke.mjs <pi|openclaw|hermes|dsh>");
   process.exit(2);
 }
 
@@ -242,7 +243,88 @@ function smokeHermes() {
   });
 }
 
-const runners = { pi: smokePi, openclaw: smokeOpenclaw, hermes: smokeHermes };
+// ------------------------------------------------------------- dsh --------
+function smokeDsh() {
+  // Replicate the publish payload: stage shared dirs, build dist, pack.
+  for (const d of ["tools", "skills", "schemas", "templates", "strategies", "scripts"]) {
+    sh("rm", ["-rf", join(repoRoot, "dsh", d)]);
+    sh("cp", ["-R", join(repoRoot, d), join(repoRoot, "dsh", d)]);
+  }
+  sh("npm", ["run", "build:dsh"], { cwd: repoRoot });
+  const packOut = sh("npm", ["pack"], { cwd: join(repoRoot, "dsh") });
+  const tgz = join(repoRoot, "dsh", packOut.trim().split("\n").pop());
+
+  // Isolated Harness home. The "headless" profile auto-initializes from the
+  // shipped template (dsh-base + dsh-headless) on first `dsh plugin add`;
+  // the CLI reconciles our bundle into dsh.profile.bundles from the package's
+  // dsh.bundle.patch manifest.
+  const dshHome = join(WORK, "dsh-home");
+  const env = { ...process.env, DSH_HOME: dshHome, DEEPSEEK_API_KEY: API_KEY };
+  const dsh = (args, opts = {}) => sh("dsh", args, { env, ...opts });
+
+  dsh(["plugin", "--profile", "headless", "add", tgz]);
+  const pkgDir = join(dshHome, "profiles", "headless", "node_modules", "@weaxs", "dsh-stock-analysis");
+  assertCond(existsSync(join(pkgDir, "dist", "index.js")), "installed plugin has dist/index.js");
+  assertCond(existsSync(join(pkgDir, "tools", "stock_data.py")), "installed plugin has tools/");
+
+  // Profile installs go through pnpm, which skips dependency lifecycle scripts
+  // without an allowBuilds entry — set the python env up like the docs tell
+  // users to.
+  if (!existsSync(join(pkgDir, ".venv"))) {
+    sh("node", [join(pkgDir, "scripts", "setup-python.mjs")], { cwd: pkgDir, env });
+  }
+
+  // Non-default endpoint/model overrides ride the documented surfaces: the
+  // `llm-deepseek:` section of $DSH_HOME/settings.yaml (what the Models page
+  // writes) and a --patch overlay replacing the agent-default-model row.
+  // The CI defaults (api.deepseek.com / deepseek-v4-flash) need neither —
+  // the key resolves from the inherited DEEPSEEK_API_KEY env per request.
+  const bootArgs = ["--profile", "headless"];
+  if (BASE_URL && BASE_URL !== "https://api.deepseek.com") {
+    writeFileSync(join(dshHome, "settings.yaml"), `llm-deepseek:\n  baseURL: ${BASE_URL}\n`);
+  }
+  if (MODEL !== "deepseek-v4-flash") {
+    const overlay = join(WORK, "dsh-model-overlay.yml");
+    writeFileSync(
+      overlay,
+      `- id: agent-default-model\n  config:\n    provider: deepseek-official\n    model: ${MODEL}\n`
+    );
+    bootArgs.push("--patch", overlay);
+  }
+
+  retryQA("dsh", () => {
+    // The headless runner prints the last assistant text to stdout and exits
+    // non-zero on an incompleted turn — catch so a failed attempt retries.
+    let out = "";
+    try {
+      out = dsh([...bootArgs, QUESTION], { timeout: 480_000 });
+    } catch (err) {
+      const tail = String(err.stdout ?? "") + String(err.stderr ?? "");
+      return { ok: false, log: `exit=${err.status ?? "?"}`, tail: tail.slice(-800) };
+    }
+    // Tool-call trace lives in the persisted session event logs:
+    // $DSH_HOME/sessions/<cwd-slug>/session-*/session.jsonl.zstd
+    let calledGetQuote = false;
+    const sessionsRoot = join(dshHome, "sessions");
+    if (existsSync(sessionsRoot)) {
+      for (const slug of readdirSync(sessionsRoot)) {
+        for (const dir of readdirSync(join(sessionsRoot, slug))) {
+          const log = join(sessionsRoot, slug, dir, "session.jsonl.zstd");
+          if (existsSync(log) && zstdDecompressSync(readFileSync(log)).toString("utf-8").includes("get_quote")) {
+            calledGetQuote = true;
+          }
+        }
+      }
+    }
+    return {
+      ok: calledGetQuote && /\d/.test(out),
+      log: `toolCalled=${calledGetQuote} final=${out.trim().slice(0, 80)}`,
+      tail: out,
+    };
+  });
+}
+
+const runners = { pi: smokePi, openclaw: smokeOpenclaw, hermes: smokeHermes, dsh: smokeDsh };
 try {
   await runners[host]();
   console.log(`\nOK: ${host} real-host smoke passed`);

--- a/tests/e2e/host_smoke.mjs
+++ b/tests/e2e/host_smoke.mjs
@@ -21,7 +21,6 @@ import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { promisify } from "node:util";
-import { zstdDecompressSync } from "node:zlib";
 
 const execFileAsync = promisify(execFile);
 const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..");
@@ -279,18 +278,33 @@ function smokeDsh() {
   // writes) and a --patch overlay replacing the agent-default-model row.
   // The CI defaults (api.deepseek.com / deepseek-v4-flash) need neither —
   // the key resolves from the inherited DEEPSEEK_API_KEY env per request.
-  const bootArgs = ["--profile", "headless"];
   if (BASE_URL && BASE_URL !== "https://api.deepseek.com") {
     writeFileSync(join(dshHome, "settings.yaml"), `llm-deepseek:\n  baseURL: ${BASE_URL}\n`);
   }
+
+  // One --patch overlay for the whole smoke:
+  //   - smoke-tool-spy: logs every executed tool name (dsh's durable session
+  //     log only carries the session header in one-shot runs, so the spy —
+  //     via the emit-mode `tools/result` event — is the tool-call trace).
+  //   - tool-web disabled: removes the built-in web_search fallback so the
+  //     model must reach the price through OUR get_quote, not a search.
+  //   - agent-default-model: only when SMOKE_LLM_MODEL is non-default.
+  const calledToolsLog = join(WORK, "dsh-called-tools.log");
+  const spyPlugin = join(repoRoot, "tests", "e2e", "dsh_tool_spy.mjs");
+  let overlay =
+    `- insert:\n` +
+    `    - id: smoke-tool-spy\n` +
+    `      name: "${spyPlugin}"\n` +
+    `      config:\n` +
+    `        logFile: "${calledToolsLog}"\n` +
+    `- id: tool-web\n` +
+    `  disabled: true\n`;
   if (MODEL !== "deepseek-v4-flash") {
-    const overlay = join(WORK, "dsh-model-overlay.yml");
-    writeFileSync(
-      overlay,
-      `- id: agent-default-model\n  config:\n    provider: deepseek-official\n    model: ${MODEL}\n`
-    );
-    bootArgs.push("--patch", overlay);
+    overlay += `- id: agent-default-model\n  config:\n    provider: deepseek-official\n    model: ${MODEL}\n`;
   }
+  const overlayPath = join(WORK, "dsh-smoke-overlay.yml");
+  writeFileSync(overlayPath, overlay);
+  const bootArgs = ["--profile", "headless", "--patch", overlayPath];
 
   retryQA("dsh", () => {
     // The headless runner prints the last assistant text to stdout and exits
@@ -302,23 +316,11 @@ function smokeDsh() {
       const tail = String(err.stdout ?? "") + String(err.stderr ?? "");
       return { ok: false, log: `exit=${err.status ?? "?"}`, tail: tail.slice(-800) };
     }
-    // Tool-call trace lives in the persisted session event logs:
-    // $DSH_HOME/sessions/<cwd-slug>/session-*/session.jsonl.zstd
-    let calledGetQuote = false;
-    const sessionsRoot = join(dshHome, "sessions");
-    if (existsSync(sessionsRoot)) {
-      for (const slug of readdirSync(sessionsRoot)) {
-        for (const dir of readdirSync(join(sessionsRoot, slug))) {
-          const log = join(sessionsRoot, slug, dir, "session.jsonl.zstd");
-          if (existsSync(log) && zstdDecompressSync(readFileSync(log)).toString("utf-8").includes("get_quote")) {
-            calledGetQuote = true;
-          }
-        }
-      }
-    }
+    const calledTools = existsSync(calledToolsLog) ? readFileSync(calledToolsLog, "utf-8") : "";
+    const calledGetQuote = calledTools.split("\n").includes("get_quote");
     return {
       ok: calledGetQuote && /\d/.test(out),
-      log: `toolCalled=${calledGetQuote} final=${out.trim().slice(0, 80)}`,
+      log: `toolCalled=${calledGetQuote} tools=[${calledTools.trim().replaceAll("\n", ",")}] final=${out.trim().slice(0, 80)}`,
       tail: out,
     };
   });

--- a/tests/e2e/test_dsh_e2e.ts
+++ b/tests/e2e/test_dsh_e2e.ts
@@ -1,0 +1,102 @@
+// Layer 1 e2e: dsh host → real Python subprocess → JSON round-trip.
+//
+// dsh/index.ts already exposes __setExecutor for tests. We do NOT call it
+// here — the default executor spawns real python. Same 4 non-network tools
+// as the pi/openclaw e2e.
+
+import { fileURLToPath } from "url";
+import { dirname, join } from "path";
+import { createJiti } from "jiti";
+
+const here = dirname(fileURLToPath(import.meta.url));
+
+interface ToolDef {
+  name: string;
+  execute: (args: Record<string, unknown>, exec: unknown) => Promise<string>;
+}
+
+// defineTool identity stub — the options object is the definition.
+const jiti = createJiti(fileURLToPath(import.meta.url), {
+  alias: {
+    "@deepseek-ai/dsh-tools": join(here, "..", "_stubs/dsh-tools.ts"),
+  },
+});
+
+const mod = (await jiti.import("../../dsh/index.ts")) as {
+  apply: (ctx: unknown) => void;
+  // Note: NOT calling __setExecutor — default spawns real python
+};
+
+const tools: ToolDef[] = [];
+mod.apply({
+  tools: {
+    register(t: ToolDef) {
+      tools.push(t);
+    },
+  },
+  skills: { register() {} },
+});
+
+// --- Assertions -----------------------------------------------------------
+
+let failures = 0;
+function assert(cond: boolean, msg: string) {
+  if (!cond) {
+    console.error(`  FAIL: ${msg}`);
+    failures++;
+  }
+}
+
+async function callTool(name: string, args: Record<string, unknown>): Promise<any> {
+  const tool = tools.find((t) => t.name === name);
+  if (!tool) throw new Error(`tool not registered: ${name}`);
+  // dsh contract: execute returns the canonical value (the CLI's JSON text).
+  const text = await tool.execute(args, {});
+  return JSON.parse(text);
+}
+
+console.log("dsh e2e host→python round-trip");
+
+// Same 4 tools as Pi/OpenClaw e2e
+{
+  const out = await callTool("get_market_capabilities", { market: "US" });
+  assert(out.market === "US", "capabilities: market");
+  assert(out.meta?.provider === "capabilities", "capabilities: meta");
+  console.log("  OK: get_market_capabilities");
+}
+
+{
+  const out = await callTool("parse_stock_list", { text: "AAPL 600519" });
+  const symbols = new Set(out.items.map((i: any) => i.symbol));
+  assert(symbols.has("AAPL"), "parse: AAPL");
+  assert(symbols.has("600519"), "parse: 600519");
+  console.log("  OK: parse_stock_list");
+}
+
+{
+  const out = await callTool("render_stock_report", {
+    report: {
+      stock_name: "dsh-e2e",
+      stock_code: "AAPL",
+      decision_type: "hold",
+      sentiment_score: 50,
+      confidence: "low",
+    },
+    template: "brief",
+  });
+  assert(out.format === "markdown", "render: format");
+  assert(String(out.content).includes("dsh-e2e"), "render: content");
+  console.log("  OK: render_stock_report");
+}
+
+{
+  const out = await callTool("diagnose_data_sources", { market: "A" });
+  assert(out.meta?.provider === "diagnostics", "diagnose: meta");
+  console.log("  OK: diagnose_data_sources");
+}
+
+if (failures > 0) {
+  console.error(`\n${failures} check(s) failed`);
+  process.exit(1);
+}
+console.log("\nAll dsh e2e round-trip checks passed");

--- a/tests/test_dsh_integration.ts
+++ b/tests/test_dsh_integration.ts
@@ -1,0 +1,284 @@
+// Layer 1 integration: dsh plugin registration.
+//
+// Loads dsh/index.ts via jiti with @deepseek-ai/dsh-tools aliased to a stub
+// (defineTool is identity, so the options object is captured verbatim).
+// Verifies:
+//   - the plugin exports the cordis function-plugin form (name/inject/apply)
+//   - all 39 tools register, aligned with the canonical cross-host tool list
+//     (openclaw.plugin.json contracts.tools — the repo invariant says every
+//     host exposes the same set)
+//   - the dsh bundle manifest (package.json dsh.bundle.patch + cordis.patch.yml)
+//     is wired for the profile loader
+//   - every tool's execute() dispatches to a tools/*.py CLI (stubbed executor)
+//   - every skills/*/SKILL.md registers as a dsh skill
+
+import { readFileSync, readdirSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import { createJiti } from "jiti";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const repoRoot = join(here, "..");
+
+interface ToolDef {
+  name: string;
+  description: string;
+  parameters: Record<string, unknown>;
+  output: {
+    schema: { type: string };
+    render: (args: unknown, value: string) => { type: string; text: string }[];
+  };
+  execute: (args: Record<string, unknown>, exec: unknown) => Promise<string>;
+}
+
+const tools: ToolDef[] = [];
+const skills: { name: string; description: string; content: string; path?: string }[] = [];
+
+const fakeCtx = {
+  tools: {
+    register(tool: ToolDef) {
+      tools.push(tool);
+    },
+  },
+  skills: {
+    register(skill: (typeof skills)[number]) {
+      skills.push(skill);
+    },
+  },
+};
+
+// --- Capture execFile calls without actually spawning Python --------------
+
+const execCalls: { script: string; args: string[] }[] = [];
+
+const jiti = createJiti(fileURLToPath(import.meta.url), {
+  alias: {
+    "@deepseek-ai/dsh-tools": join(here, "_stubs/dsh-tools.ts"),
+  },
+});
+
+const mod = (await jiti.import("../dsh/index.ts")) as {
+  name: string;
+  inject: string[];
+  apply: (ctx: unknown) => void;
+  __setExecutor: (fn: (bin: string, argv: string[]) => Promise<string>) => void;
+};
+
+mod.__setExecutor(async (_bin, argv) => {
+  const [scriptPath, ...rest] = argv;
+  execCalls.push({ script: scriptPath, args: rest });
+  return `mock:${scriptPath}`;
+});
+
+mod.apply(fakeCtx);
+
+// --- Assertions -----------------------------------------------------------
+
+let failures = 0;
+function assert(cond: boolean, msg: string) {
+  if (!cond) {
+    console.error(`  FAIL: ${msg}`);
+    failures++;
+  }
+}
+
+console.log("Plugin entry:");
+assert(mod.name === "stock-analysis", `plugin name: ${mod.name}`);
+assert(mod.inject.includes("tools"), "inject must include 'tools'");
+assert(mod.inject.includes("skills"), "inject must include 'skills'");
+
+console.log("Bundle manifest:");
+const pkg = JSON.parse(readFileSync(join(repoRoot, "dsh/package.json"), "utf8")) as {
+  name: string;
+  dsh?: { bundle?: { patch?: string } };
+};
+assert(pkg.dsh?.bundle?.patch === "./cordis.patch.yml", "package.json must declare dsh.bundle.patch");
+const patch = readFileSync(join(repoRoot, "dsh/cordis.patch.yml"), "utf8");
+assert(patch.includes("insert:"), "cordis.patch.yml must insert an entry");
+assert(
+  patch.includes(`name: "${pkg.name}"`) || patch.includes(`name: '${pkg.name}'`),
+  `cordis.patch.yml must reference the package name ${pkg.name}`
+);
+
+console.log("Tools registered:");
+const canonical = JSON.parse(
+  readFileSync(join(repoRoot, "openclaw/openclaw.plugin.json"), "utf8")
+) as { contracts: { tools: string[] } };
+const registeredNames = tools.map((t) => t.name).sort();
+const canonicalNames = [...canonical.contracts.tools].sort();
+
+const missingFromCode = canonicalNames.filter((n) => !registeredNames.includes(n));
+const extraInCode = registeredNames.filter((n) => !canonicalNames.includes(n));
+assert(
+  missingFromCode.length === 0,
+  `tools in canonical list but not registered: ${missingFromCode.join(", ")}`
+);
+assert(
+  extraInCode.length === 0,
+  `tools registered but missing from canonical list: ${extraInCode.join(", ")}`
+);
+assert(
+  registeredNames.length === canonicalNames.length,
+  `count mismatch: code=${registeredNames.length} canonical=${canonicalNames.length}`
+);
+
+const seen = new Set<string>();
+for (const tool of tools) {
+  assert(!seen.has(tool.name), `duplicate registration: ${tool.name}`);
+  seen.add(tool.name);
+  assert(!!tool.description, `${tool.name}: description empty`);
+  assert(
+    tool.parameters !== null && typeof tool.parameters === "object",
+    `${tool.name}: parameters must be a schema map`
+  );
+  assert(tool.output?.schema?.type === "string", `${tool.name}: output schema must be a string`);
+  const blocks = tool.output?.render({}, "x");
+  assert(
+    Array.isArray(blocks) && blocks[0]?.type === "text" && blocks[0]?.text === "x",
+    `${tool.name}: output.render must relay the value as one text block`
+  );
+  assert(typeof tool.execute === "function", `${tool.name}: execute must be a function`);
+}
+
+if (failures === 0) {
+  console.log(`  OK: ${tools.length} tools registered, canonical list aligned`);
+}
+
+// --- Smoke-test every tool's execute() -----------------------------------
+
+console.log("Tool execute() smoke test:");
+
+const sampleArgs: Record<string, Record<string, unknown>> = {
+  get_kline: { symbol: "600519" },
+  get_quote: { symbol: "600519" },
+  get_capital_flow: {},
+  get_news: { symbol: "600519" },
+  get_financials: { symbol: "600519" },
+  get_technical_analysis: { symbol: "600519" },
+  analyze_pattern: { symbol: "600519" },
+  get_market_indices: {},
+  get_sector_rankings: {},
+  get_stock_info: { symbol: "600519" },
+  get_chip_distribution: { symbol: "600519" },
+  get_market_stats: {},
+  get_fundamental_context: { symbol: "600519" },
+  screen_stocks: {},
+  run_backtest: { strategy: "x.yaml", symbol: "600519" },
+  evaluate_signal: { symbol: "600519", signal: "macd_golden_cross" },
+  resolve_stock_name: { query: "贵州茅台" },
+  check_trading_day: { market: "CN" },
+  get_trading_days: { market: "CN" },
+  calculate_ma: { symbol: "600519" },
+  get_volume_analysis: { symbol: "600519" },
+  search_stock_news: { query: "茅台" },
+  search_comprehensive_intel: { symbol: "600519" },
+  get_social_sentiment: { symbol: "AAPL" },
+  get_trending_sentiment: {},
+  extract_article: { url: "https://example.com" },
+  screen_risk: { symbol: "600519" },
+  detect_market_regime: {},
+  get_market_review: {},
+  run_watchlist_analysis: { symbols: "600519,000001" },
+  detect_anomaly: { symbol: "600519" },
+  diagnose_data_sources: {},
+  get_market_capabilities: { market: "A" },
+  render_stock_report: {
+    report: {
+      stock_name: "test",
+      stock_code: "600519",
+      decision_type: "hold",
+      sentiment_score: 50,
+      confidence: "low",
+    },
+    template: "brief",
+  },
+  render_market_report: { report: {} },
+  build_watchlist_context: { symbols: "600519,AAPL" },
+  analyze_position_context: {
+    symbol: "600519",
+    cost: 1500,
+    quantity: 100,
+    stop_loss: 1420,
+    take_profit: 1680,
+  },
+  check_alert_rules: {
+    symbol: "600519",
+    rules: [{ type: "price_below", value: 1450 }],
+  },
+  parse_stock_list: { text: "600519,AAPL" },
+};
+
+for (const tool of tools) {
+  const args = sampleArgs[tool.name] ?? {};
+  const before = execCalls.length;
+  let result: string | undefined;
+  try {
+    result = await tool.execute(args, {});
+  } catch (err) {
+    assert(false, `${tool.name}: execute threw: ${(err as Error).message}`);
+    continue;
+  }
+  assert(typeof result === "string", `${tool.name}: execute must return the raw stdout string`);
+  assert(execCalls.length > before, `${tool.name}: execute did not call Python`);
+  const lastCall = execCalls[execCalls.length - 1];
+  const scriptPath = lastCall.script.replace(/\\/g, "/"); // tolerate Windows separators
+  assert(
+    scriptPath.endsWith(".py") && scriptPath.includes("/tools/"),
+    `${tool.name}: should invoke a script under tools/, got ${lastCall.script}`
+  );
+}
+
+// Spot-check argv mapping on the base64-carrying tools.
+const alertCall = execCalls.find((c) => c.script.includes("alert_rules.py"));
+assert(!!alertCall, "check_alert_rules: no dispatch captured");
+if (alertCall) {
+  const idx = alertCall.args.indexOf("--rules-b64");
+  const decoded = JSON.parse(Buffer.from(alertCall.args[idx + 1], "base64").toString("utf-8"));
+  assert(
+    decoded[0]?.type === "price_below" && decoded[0]?.value === 1450,
+    "check_alert_rules: rules must round-trip through --rules-b64"
+  );
+}
+const parseCall = execCalls.find((c) => c.script.includes("import_parser.py"));
+assert(!!parseCall, "parse_stock_list: no dispatch captured");
+if (parseCall) {
+  const idx = parseCall.args.indexOf("--text-b64");
+  const decoded = Buffer.from(parseCall.args[idx + 1], "base64").toString("utf-8");
+  assert(decoded === "600519,AAPL", "parse_stock_list: text must round-trip through --text-b64");
+}
+
+if (failures === 0) {
+  console.log(`  OK: ${tools.length} execute() calls dispatched`);
+}
+
+// --- Skills ---------------------------------------------------------------
+
+console.log("Skills registered:");
+const skillDirs = readdirSync(join(repoRoot, "skills"), { withFileTypes: true })
+  .filter((d) => d.isDirectory())
+  .map((d) => d.name)
+  .sort();
+const skillNames = skills.map((s) => s.name).sort();
+assert(
+  JSON.stringify(skillNames) === JSON.stringify(skillDirs),
+  `skills mismatch: registered=${skillNames.join(",")} dirs=${skillDirs.join(",")}`
+);
+for (const skill of skills) {
+  assert(!!skill.description, `skill ${skill.name}: description empty`);
+  assert(skill.content.length > 0, `skill ${skill.name}: content empty`);
+  assert(!skill.content.startsWith("---"), `skill ${skill.name}: frontmatter not stripped`);
+  assert(
+    skill.path?.replace(/\\/g, "/").endsWith(`${skill.name}/SKILL.md`),
+    `skill ${skill.name}: path should point at its SKILL.md`
+  );
+}
+
+if (failures === 0) {
+  console.log(`  OK: ${skills.length} skills registered`);
+}
+
+if (failures > 0) {
+  console.error(`\n${failures} check(s) failed`);
+  process.exit(1);
+}
+console.log("\nAll dsh integration checks passed");

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,8 +7,9 @@
     "noEmit": true,
     "skipLibCheck": true,
     "esModuleInterop": true,
+    "allowJs": true,
     "types": ["node"],
     "typeRoots": ["./typings", "./node_modules/@types"]
   },
-  "include": ["pi/index.ts", "openclaw/index.ts", "typings/**/*.d.ts"]
+  "include": ["pi/index.ts", "openclaw/index.ts", "dsh/index.ts", "typings/**/*.d.ts"]
 }


### PR DESCRIPTION
## 概要
新增第四个宿主适配器 **dsh（DeepSeek Harness）**，与 pi/hermes/openclaw 平行：同一套 `tools/*.py` Python 核心，39 个工具 + 20 个 skill 全量接入。

- `dsh/index.ts` — cordis 函数式插件（`name`/`inject`/`apply`），`defineTool` ×39（`@deepseek-ai/dsh-tools`），`ctx.skills.register` 动态扫描注册 SKILL.md；中继形状与其余三宿主一致（raw JSON stdout → text block）
- `dsh/package.json` + `cordis.patch.yml` — dsh bundle 清单；`@deepseek-ai/*` 为 peerDependencies（esbuild external）
- 测试：`test_dsh_integration.ts`（39 工具与 openclaw manifest 交叉对齐 + argv 冒烟 + skills 校验）、`test_dsh_e2e.ts`（真实子进程往返，同 4 个非网络工具）
- e2e-host 冒烟：`host_smoke.mjs` 新增 `smokeDsh`（npm pack → `dsh plugin add` 进 headless profile → 真实 QA 回合，断言 session 事件日志含 `get_quote`）；CI 矩阵 `[pi, openclaw, hermes, dsh]`，钉 `@deepseek-ai/dsh@0.1.0-rc.7` + `pnpm@10`
- 发布：`publish-dsh` job（build → stage → pack 校验 → npm publish）；`sync-version.sh` 五清单 lockstep
- 文档：README 同步四宿主（顺手修正既有 31→39 计数漂移）；AGENTS.md 的四宿主更新在 `docs/agents-md` 分支（该文件由该分支引入）

## 验证
- `tsc --noEmit` / ruff / pytest（452）全绿；四宿主注册测试 + e2e 全过
- 真实 dsh CLI 实测：`plugin add` → bundle 协调 → `--dump-config` 含本插件 layer → headless boot 到 LLM 调用
- 真实 `defineTool`/`SkillService` 下 39 工具 schema + 20 skill 注册校验通过
- e2e-host 冒烟链路本地无密钥跑到 LLM 调用前最后一步（AUTH 处按预期失败）；真实 QA 回合由 CI 首次运行确认