### PR TITLE
ci: 每次发布同时发 scoped + 非 scoped 双名 npm 包

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -95,6 +95,14 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
+      - name: Publish unscoped variant to npm
+        # Same payload under the unscoped name; users may install either.
+        run: |
+          npm pkg set name=stock-analysis-plugin
+          npm publish --access public --provenance
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
   publish-pypi:
     runs-on: ubuntu-latest
     needs: [lint, test]
@@ -193,6 +201,16 @@ jobs:
       - name: Publish to ClawHub
         run: clawhub package publish ./openclaw
 
+      - name: Publish unscoped variant to npm
+        # Same payload under the unscoped name. Runs after ClawHub so the
+        # manifest-facing name stays scoped for the clawhub publish.
+        working-directory: openclaw
+        run: |
+          npm pkg set name=openclaw-stock-analysis
+          npm publish --access public --provenance
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
   publish-dsh:
     runs-on: ubuntu-latest
     needs: [lint, test]
@@ -244,6 +262,20 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
+      - name: Publish unscoped variant to npm
+        # The bundle manifest references the plugin by package name, so the
+        # unscoped variant's patch (and README install command) must name the
+        # unscoped package — otherwise a profile installing it would resolve
+        # the scoped name at boot and fail.
+        working-directory: dsh
+        run: |
+          npm pkg set name=dsh-stock-analysis
+          sed -i 's|@weaxs/dsh-stock-analysis|dsh-stock-analysis|g' cordis.patch.yml README.md
+          grep -q 'name: "dsh-stock-analysis"' cordis.patch.yml
+          npm publish --access public --provenance
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
   github-release:
     runs-on: ubuntu-latest
     needs: [publish-npm, publish-pypi, publish-openclaw, publish-dsh]
@@ -266,6 +298,7 @@ jobs:
           - **pip**: \`pip install stock-analysis-plugin==${VERSION}\`
           - **OpenClaw**: \`openclaw plugins install clawhub:@weaxs/openclaw-stock-analysis\`
           - **dsh**: \`dsh plugin --profile <name> add @weaxs/dsh-stock-analysis\`
+          - 非 scoped 同名变体（内容一致）：\`stock-analysis-plugin\` / \`openclaw-stock-analysis\` / \`dsh-stock-analysis\`
           EOF
 
       - name: Create GitHub Release

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -186,6 +186,7 @@ Versions live in **five** manifests that must stay in lockstep: `pyproject.toml`
 - `scripts/sync-version.sh` is idempotent and validates the tag shape; you can dry-run it locally with `GITHUB_REF_NAME=v9.9.9 scripts/sync-version.sh`.
 - Verify package contents before publishing: `npm pack --dry-run` (the `build` CI job does this and uploads the tarball).
 - Build the OpenClaw bundle with `npm run build:openclaw` (esbuild → `openclaw/dist/index.js`) and the dsh bundle with `npm run build:dsh` (esbuild → `dsh/dist/index.js`, `@deepseek-ai/*` external).
+- **Each npm package ships under two names**: the canonical `@weaxs/*` scoped name and an unscoped twin with identical payload (twin steps in `publish.yml`, right after each scoped publish). The dsh twin additionally rewrites the package-name reference in `cordis.patch.yml` and the README install command before publishing — a profile installing the unscoped variant resolves the plugin by that name at boot. If a manifest or package name ever changes, update the twin steps in the same change.
 - The `postinstall` (`scripts/setup-python.mjs`) builds the repo `.venv` and installs `tools/requirements.txt`. Syntax-check it with `node --check scripts/setup-python.mjs` after edits.
 
 ---

--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ A 股 / 港股 / 美股 / 日股 / 韩股 / 台股综合分析、多因子选股
 
 ## 安装
 
+> 所有 npm 包同时以 scoped（`@weaxs/*`）和非 scoped 同名两种名字发布，内容一致，任选其一即可。
+
 ### Pi Agent Extension
 
 ```bash


### PR DESCRIPTION
## 概要
三个 npm 包在每次 tag 发布时，除 canonical 的 `@weaxs/*` scoped 名外，同步发布一个**非 scoped 同名变体**（负载完全一致）：

| scoped（canonical） | 非 scoped 变体 |
|---|---|
| `@weaxs/stock-analysis-plugin` | `stock-analysis-plugin` |
| `@weaxs/openclaw-stock-analysis` | `openclaw-stock-analysis` |
| `@weaxs/dsh-stock-analysis` | `dsh-stock-analysis` |

## 实现
- **publish-npm / publish-openclaw**：scoped 发布后 `npm pkg set name=<unscoped>` 再发一次。openclaw 的变体发布放在 clawhub 步骤之后，避免改写包名影响 clawhub 发布
- **publish-dsh**：变体发布前用 sed 把 `cordis.patch.yml` 和 README 安装命令中的 `@weaxs/dsh-stock-analysis` 改写为 `dsh-stock-analysis`——bundle manifest 按包名引用插件入口，不改写则安装非 scope 包的 profile 在 boot 时解析 scoped 名失败；带 grep 守卫
- github-release footer 增加变体说明；AGENTS.md Versioning 节记录双名发布规则；README 安装节一行说明

## 验证
- 本地完整模拟 publish-dsh twin 链路：重写 → 打包 → `dsh plugin add` 进真实 headless profile → `--dump-config` 层名为 `dsh-stock-analysis` → mock LLM 全回合 `get_quote` 往返通过（305.59）
- 三个非 scope 名已确认均未被占用（npm view E404）
- publish.yml YAML 校验通过

合并后打 `v0.1.10` 即可首发六个包。