### PR TITLE
docs: 工具描述路由信息 + stock-analysis 意图路由表

### DIFF
--- a/dsh/index.ts
+++ b/dsh/index.ts
@@ -122,7 +122,7 @@ export function apply(ctx: Context) {
     pyTool({
       name: "get_kline",
       description:
-        "获取股票K线数据（OHLCV）。支持A股（如600519）、港股（如00700.HK）、美股（如AAPL）、日股（如7203.T）、韩股（如005930.KS）、台股（如2330.TW）及A股ETF",
+        "获取股票K线数据（OHLCV）。支持A股（如600519）、港股（如00700.HK）、美股（如AAPL）、日股（如7203.T）、韩股（如005930.KS）、台股（如2330.TW）及A股ETF。需要原始历史价格自行计算或画图时用；只问指标用 get_technical_analysis，只问现价用 get_quote",
       parameters: {
         symbol: {
           type: "string",
@@ -152,7 +152,7 @@ export function apply(ctx: Context) {
   ctx.tools.register(
     pyTool({
       name: "get_quote",
-      description: "获取股票实时行情报价。支持A股、港股、美股、日股、韩股、台股",
+      description: "获取股票实时行情报价（现价、涨跌幅、量比等）。支持A股、港股、美股、日股、韩股、台股。问“现在多少钱/涨了多少”用本工具",
       parameters: {
         symbol: { type: "string", required: true, description: "股票代码" },
       },
@@ -165,7 +165,7 @@ export function apply(ctx: Context) {
     pyTool({
       name: "get_capital_flow",
       description:
-        "获取A股资金流向数据。detail=个股每日明细，summary=多日汇总+趋势，sector_flow=板块资金流排行",
+        "获取A股资金流向（主力/超大单/大单/中单/小单净流入）。detail=个股每日明细，summary=多日汇总+趋势，sector_flow=板块资金流排行。问“主力在买还是卖/资金流入流出”用本工具，可配合 get_chip_distribution 验证",
       parameters: {
         symbol: {
           type: "string",
@@ -190,7 +190,7 @@ export function apply(ctx: Context) {
   ctx.tools.register(
     pyTool({
       name: "get_news",
-      description: "获取股票相关财经新闻",
+      description: "获取个股最近N天财经新闻快讯（轻量、无需配置）。需要深度全网情报用 search_comprehensive_intel，按主题搜索用 search_stock_news，读文章全文用 extract_article",
       parameters: {
         symbol: { type: "string", required: true, description: "股票代码" },
         days: { type: "number", description: "获取最近几天的新闻，默认 3" },
@@ -203,7 +203,7 @@ export function apply(ctx: Context) {
   ctx.tools.register(
     pyTool({
       name: "get_financials",
-      description: "获取股票关键财务指标（PE/PB/市值/营收/净利润/ROE等）",
+      description: "获取股票关键财务指标（PE/PB/市值/营收/净利润/ROE等），适合快速估值快查。A股深度基本面（成长性/盈利能力/分红）用 get_fundamental_context",
       parameters: {
         symbol: { type: "string", required: true, description: "股票代码" },
       },
@@ -218,7 +218,7 @@ export function apply(ctx: Context) {
     pyTool({
       name: "get_technical_analysis",
       description:
-        "获取股票技术面分析（MA/MACD/RSI/BOLL/KDJ/成交量等指标 + 100分综合评分 + 6级买卖信号 + 趋势/偏离度/支撑压力位）",
+        "获取股票技术面分析（MA/MACD/RSI/BOLL/KDJ/成交量等指标 + 100分综合评分 + 6级买卖信号 + 趋势/偏离度/支撑压力位）。“能买吗/现在能入场吗/技术面怎么样”首选本工具；只要均线数值或自定义周期用 calculate_ma，专问量价用 get_volume_analysis，扫当日异动用 detect_anomaly",
       parameters: {
         symbol: { type: "string", required: true, description: "股票代码" },
         period: {
@@ -244,7 +244,7 @@ export function apply(ctx: Context) {
     pyTool({
       name: "analyze_pattern",
       description:
-        "K线形态识别 — 检测十字星、锤子线、吞没、启明星、黄昏星、双底、20日突破等12+种经典形态",
+        "K线形态识别 — 检测十字星、锤子线、吞没、启明星、黄昏星、双底、20日突破等12+种经典形态。问“出现了什么形态”时用；综合技术面判断用 get_technical_analysis",
       parameters: {
         symbol: { type: "string", required: true, description: "股票代码" },
         period: {
@@ -272,7 +272,7 @@ export function apply(ctx: Context) {
     pyTool({
       name: "get_market_indices",
       description:
-        "获取主要市场指数行情。CN: 上证/深证/创业板/科创50/沪深300；HK: 恒生/国企/科技；US: 道琼斯/纳斯达克/标普500；JP: 日经225/东证；KR: KOSPI/KOSDAQ；TW: 台湾加权",
+        "获取主要市场指数行情。CN: 上证/深证/创业板/科创50/沪深300；HK: 恒生/国企/科技；US: 道琼斯/纳斯达克/标普500；JP: 日经225/东证；KR: KOSPI/KOSDAQ；TW: 台湾加权。“复盘今天大盘”用 get_market_review 一站式获取",
       parameters: {
         region: {
           type: "string",
@@ -289,7 +289,7 @@ export function apply(ctx: Context) {
     pyTool({
       name: "get_sector_rankings",
       description:
-        "获取A股行业板块涨跌幅排行（含领涨股、涨跌家数等）。支持查看涨幅榜/跌幅榜/双向",
+        "获取A股行业板块涨跌幅排行（含领涨股、涨跌家数等）。支持查看涨幅榜/跌幅榜/双向。找热点板块/领涨板块用本工具",
       parameters: {
         top: { type: "number", description: "返回排名前N的板块，默认 10" },
         direction: {
@@ -326,7 +326,7 @@ export function apply(ctx: Context) {
     pyTool({
       name: "get_chip_distribution",
       description:
-        "获取A股筹码分布数据（获利比例、平均成本、90%/70%成本集中度）。仅支持A股",
+        "获取A股筹码分布数据（获利比例、平均成本、90%/70%成本集中度）。仅支持A股。与 get_capital_flow 配合验证主力行为",
       parameters: {
         symbol: {
           type: "string",
@@ -343,7 +343,7 @@ export function apply(ctx: Context) {
     pyTool({
       name: "get_market_stats",
       description:
-        "获取A股市场整体统计（涨跌家数、涨停跌停数、平均涨幅、涨跌Top5、总成交额）",
+        "获取A股市场整体统计（涨跌家数、涨停跌停数、平均涨幅、涨跌Top5、总成交额）。问“今天市场情绪/温度如何”用本工具",
       parameters: {
         market: {
           type: "string",
@@ -360,7 +360,7 @@ export function apply(ctx: Context) {
     pyTool({
       name: "get_fundamental_context",
       description:
-        "获取A股深度基本面（估值PE/PB/PS + 成长性营收/净利增速 + 盈利能力ROE/毛利率 + 分红历史）",
+        "获取A股深度基本面（估值PE/PB/PS + 成长性营收/净利增速 + 盈利能力ROE/毛利率 + 分红历史）。“公司质地如何/能不能长期持有”用本工具；快速查PE/PB用 get_financials",
       parameters: {
         symbol: {
           type: "string",
@@ -379,7 +379,7 @@ export function apply(ctx: Context) {
     pyTool({
       name: "screen_stocks",
       description:
-        "全市场股票筛选（AlphaSift L1 多因子硬筛）。按PE/PB/市值/换手率/涨跌幅/量比等因子过滤和评分",
+        "全市场股票筛选（AlphaSift L1 多因子硬筛）。按PE/PB/市值/换手率/涨跌幅/量比等因子过滤和评分。“帮我选股/筛选低估值/高换手股票”用本工具",
       parameters: {
         market: {
           type: "string",
@@ -402,7 +402,7 @@ export function apply(ctx: Context) {
     pyTool({
       name: "run_backtest",
       description:
-        "策略回测（AlphaEvo）。读取YAML策略定义，在历史数据上模拟交易，输出收益率/回撤/胜率等指标",
+        "策略回测（AlphaEvo）。读取YAML策略定义，在历史数据上模拟交易，输出收益率/回撤/胜率等指标。只想知道单个技术信号的历史胜率用更轻量的 evaluate_signal",
       parameters: {
         strategy: { type: "string", required: true, description: "策略YAML文件路径" },
         symbol: { type: "string", required: true, description: "股票代码" },
@@ -425,7 +425,7 @@ export function apply(ctx: Context) {
     pyTool({
       name: "evaluate_signal",
       description:
-        "技术信号历史准确率评估 — 回溯历史数据，统计某个技术信号触发后N日的胜率和平均收益。支持9种信号：macd_golden_cross/macd_death_cross/rsi_oversold/rsi_overbought/breakout_20d/breakdown_20d/volume_surge/ma_golden_cross/ma_death_cross",
+        "技术信号历史准确率评估 — 回溯历史数据，统计某个技术信号触发后N日的胜率和平均收益。支持9种信号：macd_golden_cross/macd_death_cross/rsi_oversold/rsi_overbought/breakout_20d/breakdown_20d/volume_surge/ma_golden_cross/ma_death_cross。“金叉/突破策略靠不靠谱”用本工具；要完整模拟交易过程用 run_backtest",
       parameters: {
         symbol: { type: "string", required: true, description: "股票代码" },
         signal: {
@@ -469,7 +469,7 @@ export function apply(ctx: Context) {
     pyTool({
       name: "resolve_stock_name",
       description:
-        "股票名称智能解析 — 输入中文名（贵州茅台）、拼音（guizhou maotai/gzmt）、部分代码，返回匹配的股票代码。仅支持A股",
+        "股票名称智能解析 — 输入中文名（贵州茅台）、拼音（guizhou maotai/gzmt）、部分代码，返回匹配的股票代码。仅支持A股。用户给出中文名/拼音/部分代码时先调本工具换成代码再调其他工具",
       parameters: {
         query: {
           type: "string",
@@ -542,7 +542,7 @@ export function apply(ctx: Context) {
     pyTool({
       name: "calculate_ma",
       description:
-        "独立均线计算器 — 支持任意周期MA（5/10/20/30/60/120/250或自定义）+ 偏离度 + 均线排列 + 金叉死叉检测",
+        "独立均线计算器 — 支持任意周期MA（5/10/20/30/60/120/250或自定义）+ 偏离度 + 均线排列 + 金叉死叉检测。只要均线数值或需要30/120/250等非默认周期时用本工具；综合技术面分析用 get_technical_analysis",
       parameters: {
         symbol: { type: "string", required: true, description: "股票代码" },
         periods: {
@@ -575,7 +575,7 @@ export function apply(ctx: Context) {
     pyTool({
       name: "get_volume_analysis",
       description:
-        "独立量价分析 — 量价相关性、上涨/下跌日成交量对比、量能趋势、量价模式解读（放量上涨/缩量回调等）",
+        "独立量价分析 — 量价相关性、上涨/下跌日成交量对比、量能趋势、量价模式解读（放量上涨/缩量回调等）。专问量能/量价配合时用本工具；综合技术面判断用 get_technical_analysis，扫当日异动用 detect_anomaly",
       parameters: {
         symbol: { type: "string", required: true, description: "股票代码" },
         period: {
@@ -603,7 +603,7 @@ export function apply(ctx: Context) {
     pyTool({
       name: "search_stock_news",
       description:
-        "多引擎股票新闻搜索（支持 Tavily/Brave/SerpAPI）。需配置对应 API Key 环境变量",
+        "多引擎股票新闻搜索（支持 Tavily/Brave/SerpAPI）。需配置对应 API Key 环境变量。get_news 快讯不够或要按主题搜索时用本工具；深度6维情报用 search_comprehensive_intel",
       parameters: {
         query: { type: "string", required: true, description: "搜索关键词" },
         count: { type: "number", description: "返回结果数量，默认 10" },
@@ -617,7 +617,7 @@ export function apply(ctx: Context) {
     pyTool({
       name: "search_comprehensive_intel",
       description:
-        "股票综合情报搜索 — 从6个维度（新闻/公告/行情分析/风险/业绩/行业）搜索综合信息",
+        "股票综合情报搜索 — 从6个维度（新闻/公告/行情分析/风险/业绩/行业）搜索综合信息。“深入研究/全面调研这家公司”用本工具；快速看新闻用 get_news",
       parameters: {
         symbol: { type: "string", required: true, description: "股票代码" },
         name: { type: "string", description: "股票名称（可选，提升搜索准确度）" },
@@ -635,7 +635,7 @@ export function apply(ctx: Context) {
     pyTool({
       name: "get_social_sentiment",
       description:
-        "获取股票社交媒体情绪数据（Reddit/X/Polymarket）。主要支持美股。需配置 SENTIMENT_API_KEY",
+        "获取股票社交媒体情绪数据。A股：东方财富股吧热度+雪球讨论热度（无需配置）；美股/港股：Reddit/X/Polymarket情绪（需 SENTIMENT_API_KEY）。自动按市场选数据源。“散户在讨论什么/情绪如何”用本工具；看全市场热门讨论用 get_trending_sentiment",
       parameters: {
         symbol: { type: "string", required: true, description: "股票代码（如 AAPL）" },
       },
@@ -648,7 +648,7 @@ export function apply(ctx: Context) {
     pyTool({
       name: "get_trending_sentiment",
       description:
-        "获取社交媒体热门趋势（Reddit/X/Polymarket热门股票讨论）。数据缓存10分钟。适用于发现市场热点",
+        "获取社交媒体热门趋势（Reddit/X/Polymarket热门股票讨论）。数据缓存10分钟。“现在市场热点是什么/大家都在买什么”用本工具；查个股情绪用 get_social_sentiment",
       parameters: {},
       script: "search_intel.py",
       argv: () => ["trending"],
@@ -659,7 +659,7 @@ export function apply(ctx: Context) {
     pyTool({
       name: "extract_article",
       description:
-        "网页文章全文提取 — 输入URL，提取文章标题、正文（最多3000字）、作者、发布日期等。适用于深度阅读搜索结果中的新闻/研报",
+        "网页文章全文提取 — 输入URL，提取文章标题、正文（最多3000字）、作者、发布日期等。配合 get_news/search_stock_news 的搜索结果做深度阅读",
       parameters: {
         url: { type: "string", required: true, description: "文章URL" },
       },
@@ -672,7 +672,7 @@ export function apply(ctx: Context) {
     pyTool({
       name: "screen_risk",
       description:
-        "风险专项筛查 — 7维度风险检测（估值极端/技术预警/解禁到期/内部人减持/业绩预警/监管处罚/行业政策），返回风险评级和一票否决标记",
+        "风险专项筛查 — 7维度风险检测（估值极端/技术预警/解禁到期/内部人减持/业绩预警/监管处罚/行业政策），返回风险评级和一票否决标记。“这股票有什么雷”用本工具；入场决策前排雷必调",
       parameters: {
         symbol: {
           type: "string",
@@ -694,7 +694,7 @@ export function apply(ctx: Context) {
     pyTool({
       name: "detect_market_regime",
       description:
-        "市场状态检测 — 分析大盘指数判断当前市场阶段（上涨趋势/下跌趋势/横盘震荡/高波动/板块热点），并推荐适合的分析策略",
+        "市场状态检测 — 分析大盘指数判断当前市场阶段（上涨趋势/下跌趋势/横盘震荡/高波动/板块热点），并推荐适合的分析策略。“现在大盘能进场吗/该用什么策略”用本工具",
       parameters: {
         market: {
           type: "string",
@@ -711,7 +711,7 @@ export function apply(ctx: Context) {
     pyTool({
       name: "get_market_review",
       description:
-        "大盘复盘 — 获取市场日度复盘数据，包含指数、涨跌统计、板块排名、新闻、市场温度与策略建议",
+        "大盘复盘 — 获取市场日度复盘数据，包含指数、涨跌统计、板块排名、新闻、市场温度与策略建议。“复盘一下今天市场/今天大盘怎么样”首选本工具，无需再分别调指数/统计/板块工具",
       parameters: {
         market: {
           type: "string",
@@ -728,7 +728,7 @@ export function apply(ctx: Context) {
     pyTool({
       name: "run_watchlist_analysis",
       description:
-        "批量自选股分析 — 对多只股票并行采集行情/技术/资金/风险等数据，返回汇总结果。适用于每日定时分析自选股列表",
+        "批量自选股分析 — 对多只股票并行采集行情/技术/资金/风险等数据，返回汇总结果。“批量分析我的自选股”/每日定时分析用本工具",
       parameters: {
         symbols: {
           type: "string",
@@ -749,7 +749,7 @@ export function apply(ctx: Context) {
     pyTool({
       name: "detect_anomaly",
       description:
-        "异常/事件检测 — 一键扫描股票当前所有异动信号（MACD金叉死叉、RSI超买超卖、20日突破、放量异动、涨跌停、布林突破、KDJ极值、资金异动等），返回结构化异常列表",
+        "异常/事件检测 — 一键扫描股票当前所有异动信号（MACD金叉死叉、RSI超买超卖、20日突破、放量异动、涨跌停、布林突破、KDJ极值、资金异动等），返回结构化异常列表。“今天有什么异动/为什么大涨大跌”首选本工具；综合技术面判断用 get_technical_analysis",
       parameters: {
         symbol: {
           type: "string",
@@ -768,7 +768,7 @@ export function apply(ctx: Context) {
     pyTool({
       name: "diagnose_data_sources",
       description:
-        "数据源诊断 — 检查当前环境可用的数据 provider（akshare/tushare/yfinance/finnhub/longbridge/alphavantage），输出每个市场的可用链路、缺失 env、warnings",
+        "数据源诊断 — 检查当前环境可用的数据 provider（akshare/tushare/yfinance/finnhub/longbridge/alphavantage），输出每个市场的可用链路、缺失 env、warnings。工具拿不到数据或报错时调用排查",
       parameters: {
         market: {
           type: "string",
@@ -785,7 +785,7 @@ export function apply(ctx: Context) {
     pyTool({
       name: "get_market_capabilities",
       description:
-        "市场能力边界 — 返回指定市场支持/不支持的工具列表，避免 agent 对港股调 get_chip_distribution 或对美股调 get_capital_flow 后编造数据",
+        "市场能力边界 — 返回指定市场支持/不支持的工具列表。不确定某市场能否用某工具（如港股的筹码分布、美股的资金流）时先调本工具，避免调用不支持的工具后编造数据",
       parameters: {
         market: {
           type: "string",
@@ -808,7 +808,7 @@ export function apply(ctx: Context) {
     pyTool({
       name: "render_stock_report",
       description:
-        "股票分析报告渲染 — 将结构化 JSON（符合 schemas/report_schema.json）通过 j2 模板渲染为 Markdown。template: brief|full。仅渲染，不保存不推送",
+        "股票分析报告渲染 — 将结构化 JSON（符合 schemas/report_schema.json）通过 j2 模板渲染为 Markdown。template: brief|full。全部分析完成后的最后一步调用。仅渲染，不保存不推送",
       parameters: {
         report: {
           type: "object",
@@ -884,7 +884,7 @@ export function apply(ctx: Context) {
     pyTool({
       name: "analyze_position_context",
       description:
-        "持仓上下文分析 — 输入成本/仓位/止损止盈，结合现价和技术位输出浮盈亏、离止损距离、风险级别、操作建议。无状态、不存账户",
+        "持仓上下文分析 — 输入成本/仓位/止损止盈，结合现价和技术位输出浮盈亏、离止损距离、风险级别、操作建议。“我XX成本买的被套了/要不要止损止盈”用本工具。无状态、不存账户",
       parameters: {
         symbol: { type: "string", required: true, description: "股票代码" },
         cost: { type: "number", required: true, description: "成本价" },
@@ -913,7 +913,7 @@ export function apply(ctx: Context) {
     pyTool({
       name: "check_alert_rules",
       description:
-        "无状态告警规则检查 — 传入规则数组，返回当前是否触发。规则类型：price_below/price_above/change_pct_above/change_pct_below/volume_ratio_above/anomaly/risk_veto/risk_level_at_least。不做调度不存历史",
+        "无状态告警规则检查 — 传入规则数组，返回当前是否触发。规则类型：price_below/price_above/change_pct_above/change_pct_below/volume_ratio_above/anomaly/risk_veto/risk_level_at_least。“到价/涨跌幅提醒是否触发”用本工具。不做调度不存历史",
       parameters: {
         symbol: { type: "string", required: true, description: "股票代码" },
         rules: {

--- a/dsh/index.ts
+++ b/dsh/index.ts
@@ -152,7 +152,7 @@ export function apply(ctx: Context) {
   ctx.tools.register(
     pyTool({
       name: "get_quote",
-      description: "获取股票实时行情报价（现价、涨跌幅、量比等）。支持A股、港股、美股、日股、韩股、台股。问“现在多少钱/涨了多少”用本工具",
+      description: "获取股票实时行情报价（现价、涨跌幅、量比等）。支持A股、港股、美股、日股、韩股、台股",
       parameters: {
         symbol: { type: "string", required: true, description: "股票代码" },
       },
@@ -165,7 +165,7 @@ export function apply(ctx: Context) {
     pyTool({
       name: "get_capital_flow",
       description:
-        "获取A股资金流向（主力/超大单/大单/中单/小单净流入）。detail=个股每日明细，summary=多日汇总+趋势，sector_flow=板块资金流排行。问“主力在买还是卖/资金流入流出”用本工具，可配合 get_chip_distribution 验证",
+        "获取A股资金流向（主力/超大单/大单/中单/小单净流入）。detail=个股每日明细，summary=多日汇总+趋势，sector_flow=板块资金流排行。可配合 get_chip_distribution 验证主力行为",
       parameters: {
         symbol: {
           type: "string",
@@ -218,7 +218,7 @@ export function apply(ctx: Context) {
     pyTool({
       name: "get_technical_analysis",
       description:
-        "获取股票技术面分析（MA/MACD/RSI/BOLL/KDJ/成交量等指标 + 100分综合评分 + 6级买卖信号 + 趋势/偏离度/支撑压力位）。“能买吗/现在能入场吗/技术面怎么样”首选本工具；只要均线数值或自定义周期用 calculate_ma，专问量价用 get_volume_analysis，扫当日异动用 detect_anomaly",
+        "获取股票技术面分析（MA/MACD/RSI/BOLL/KDJ/成交量等指标 + 100分综合评分 + 6级买卖信号 + 趋势/偏离度/支撑压力位）。个股技术面综合判断与买卖时机分析的首选；只要均线数值或自定义周期用 calculate_ma，专问量价用 get_volume_analysis，扫当日异动用 detect_anomaly",
       parameters: {
         symbol: { type: "string", required: true, description: "股票代码" },
         period: {
@@ -244,7 +244,7 @@ export function apply(ctx: Context) {
     pyTool({
       name: "analyze_pattern",
       description:
-        "K线形态识别 — 检测十字星、锤子线、吞没、启明星、黄昏星、双底、20日突破等12+种经典形态。问“出现了什么形态”时用；综合技术面判断用 get_technical_analysis",
+        "K线形态识别 — 检测十字星、锤子线、吞没、启明星、黄昏星、双底、20日突破等12+种经典形态。综合技术面判断用 get_technical_analysis",
       parameters: {
         symbol: { type: "string", required: true, description: "股票代码" },
         period: {
@@ -272,7 +272,7 @@ export function apply(ctx: Context) {
     pyTool({
       name: "get_market_indices",
       description:
-        "获取主要市场指数行情。CN: 上证/深证/创业板/科创50/沪深300；HK: 恒生/国企/科技；US: 道琼斯/纳斯达克/标普500；JP: 日经225/东证；KR: KOSPI/KOSDAQ；TW: 台湾加权。“复盘今天大盘”用 get_market_review 一站式获取",
+        "获取主要市场指数行情。CN: 上证/深证/创业板/科创50/沪深300；HK: 恒生/国企/科技；US: 道琼斯/纳斯达克/标普500；JP: 日经225/东证；KR: KOSPI/KOSDAQ；TW: 台湾加权。大盘复盘用 get_market_review 一站式获取",
       parameters: {
         region: {
           type: "string",
@@ -289,7 +289,7 @@ export function apply(ctx: Context) {
     pyTool({
       name: "get_sector_rankings",
       description:
-        "获取A股行业板块涨跌幅排行（含领涨股、涨跌家数等）。支持查看涨幅榜/跌幅榜/双向。找热点板块/领涨板块用本工具",
+        "获取A股行业板块涨跌幅排行（含领涨股、涨跌家数等）。支持查看涨幅榜/跌幅榜/双向",
       parameters: {
         top: { type: "number", description: "返回排名前N的板块，默认 10" },
         direction: {
@@ -343,7 +343,7 @@ export function apply(ctx: Context) {
     pyTool({
       name: "get_market_stats",
       description:
-        "获取A股市场整体统计（涨跌家数、涨停跌停数、平均涨幅、涨跌Top5、总成交额）。问“今天市场情绪/温度如何”用本工具",
+        "获取A股市场整体统计（涨跌家数、涨停跌停数、平均涨幅、涨跌Top5、总成交额）。用于衡量市场整体情绪与温度",
       parameters: {
         market: {
           type: "string",
@@ -360,7 +360,7 @@ export function apply(ctx: Context) {
     pyTool({
       name: "get_fundamental_context",
       description:
-        "获取A股深度基本面（估值PE/PB/PS + 成长性营收/净利增速 + 盈利能力ROE/毛利率 + 分红历史）。“公司质地如何/能不能长期持有”用本工具；快速查PE/PB用 get_financials",
+        "获取A股深度基本面（估值PE/PB/PS + 成长性营收/净利增速 + 盈利能力ROE/毛利率 + 分红历史）。用于评估公司质地与长期持有价值；快速查PE/PB用 get_financials",
       parameters: {
         symbol: {
           type: "string",
@@ -379,7 +379,7 @@ export function apply(ctx: Context) {
     pyTool({
       name: "screen_stocks",
       description:
-        "全市场股票筛选（AlphaSift L1 多因子硬筛）。按PE/PB/市值/换手率/涨跌幅/量比等因子过滤和评分。“帮我选股/筛选低估值/高换手股票”用本工具",
+        "全市场股票筛选（AlphaSift L1 多因子硬筛）。按PE/PB/市值/换手率/涨跌幅/量比等因子过滤和评分",
       parameters: {
         market: {
           type: "string",
@@ -425,7 +425,7 @@ export function apply(ctx: Context) {
     pyTool({
       name: "evaluate_signal",
       description:
-        "技术信号历史准确率评估 — 回溯历史数据，统计某个技术信号触发后N日的胜率和平均收益。支持9种信号：macd_golden_cross/macd_death_cross/rsi_oversold/rsi_overbought/breakout_20d/breakdown_20d/volume_surge/ma_golden_cross/ma_death_cross。“金叉/突破策略靠不靠谱”用本工具；要完整模拟交易过程用 run_backtest",
+        "技术信号历史准确率评估 — 回溯历史数据，统计某个技术信号触发后N日的胜率和平均收益。支持9种信号：macd_golden_cross/macd_death_cross/rsi_oversold/rsi_overbought/breakout_20d/breakdown_20d/volume_surge/ma_golden_cross/ma_death_cross。要完整模拟交易过程用 run_backtest",
       parameters: {
         symbol: { type: "string", required: true, description: "股票代码" },
         signal: {
@@ -575,7 +575,7 @@ export function apply(ctx: Context) {
     pyTool({
       name: "get_volume_analysis",
       description:
-        "独立量价分析 — 量价相关性、上涨/下跌日成交量对比、量能趋势、量价模式解读（放量上涨/缩量回调等）。专问量能/量价配合时用本工具；综合技术面判断用 get_technical_analysis，扫当日异动用 detect_anomaly",
+        "独立量价分析 — 量价相关性、上涨/下跌日成交量对比、量能趋势、量价模式解读（放量上涨/缩量回调等）。综合技术面判断用 get_technical_analysis，扫当日异动用 detect_anomaly",
       parameters: {
         symbol: { type: "string", required: true, description: "股票代码" },
         period: {
@@ -617,7 +617,7 @@ export function apply(ctx: Context) {
     pyTool({
       name: "search_comprehensive_intel",
       description:
-        "股票综合情报搜索 — 从6个维度（新闻/公告/行情分析/风险/业绩/行业）搜索综合信息。“深入研究/全面调研这家公司”用本工具；快速看新闻用 get_news",
+        "股票综合情报搜索 — 从6个维度（新闻/公告/行情分析/风险/业绩/行业）搜索综合信息。用于个股的深入研究/全面调研；快速看新闻用 get_news",
       parameters: {
         symbol: { type: "string", required: true, description: "股票代码" },
         name: { type: "string", description: "股票名称（可选，提升搜索准确度）" },
@@ -635,7 +635,7 @@ export function apply(ctx: Context) {
     pyTool({
       name: "get_social_sentiment",
       description:
-        "获取股票社交媒体情绪数据。A股：东方财富股吧热度+雪球讨论热度（无需配置）；美股/港股：Reddit/X/Polymarket情绪（需 SENTIMENT_API_KEY）。自动按市场选数据源。“散户在讨论什么/情绪如何”用本工具；看全市场热门讨论用 get_trending_sentiment",
+        "获取股票社交媒体情绪数据。A股：东方财富股吧热度+雪球讨论热度（无需配置）；美股/港股：Reddit/X/Polymarket情绪（需 SENTIMENT_API_KEY）。自动按市场选数据源。面向个股维度；全市场热门讨论用 get_trending_sentiment",
       parameters: {
         symbol: { type: "string", required: true, description: "股票代码（如 AAPL）" },
       },
@@ -648,7 +648,7 @@ export function apply(ctx: Context) {
     pyTool({
       name: "get_trending_sentiment",
       description:
-        "获取社交媒体热门趋势（Reddit/X/Polymarket热门股票讨论）。数据缓存10分钟。“现在市场热点是什么/大家都在买什么”用本工具；查个股情绪用 get_social_sentiment",
+        "获取社交媒体热门趋势（Reddit/X/Polymarket热门股票讨论）。数据缓存10分钟。适用于发现市场热点；查个股情绪用 get_social_sentiment",
       parameters: {},
       script: "search_intel.py",
       argv: () => ["trending"],
@@ -672,7 +672,7 @@ export function apply(ctx: Context) {
     pyTool({
       name: "screen_risk",
       description:
-        "风险专项筛查 — 7维度风险检测（估值极端/技术预警/解禁到期/内部人减持/业绩预警/监管处罚/行业政策），返回风险评级和一票否决标记。“这股票有什么雷”用本工具；入场决策前排雷必调",
+        "风险专项筛查 — 7维度风险检测（估值极端/技术预警/解禁到期/内部人减持/业绩预警/监管处罚/行业政策），返回风险评级和一票否决标记。入场决策前的排雷必调本工具",
       parameters: {
         symbol: {
           type: "string",
@@ -694,7 +694,7 @@ export function apply(ctx: Context) {
     pyTool({
       name: "detect_market_regime",
       description:
-        "市场状态检测 — 分析大盘指数判断当前市场阶段（上涨趋势/下跌趋势/横盘震荡/高波动/板块热点），并推荐适合的分析策略。“现在大盘能进场吗/该用什么策略”用本工具",
+        "市场状态检测 — 分析大盘指数判断当前市场阶段（上涨趋势/下跌趋势/横盘震荡/高波动/板块热点），并推荐适合的分析策略",
       parameters: {
         market: {
           type: "string",
@@ -711,7 +711,7 @@ export function apply(ctx: Context) {
     pyTool({
       name: "get_market_review",
       description:
-        "大盘复盘 — 获取市场日度复盘数据，包含指数、涨跌统计、板块排名、新闻、市场温度与策略建议。“复盘一下今天市场/今天大盘怎么样”首选本工具，无需再分别调指数/统计/板块工具",
+        "大盘复盘 — 获取市场日度复盘数据，包含指数、涨跌统计、板块排名、新闻、市场温度与策略建议。复盘类需求的首选，无需再分别调指数/统计/板块工具",
       parameters: {
         market: {
           type: "string",
@@ -728,7 +728,7 @@ export function apply(ctx: Context) {
     pyTool({
       name: "run_watchlist_analysis",
       description:
-        "批量自选股分析 — 对多只股票并行采集行情/技术/资金/风险等数据，返回汇总结果。“批量分析我的自选股”/每日定时分析用本工具",
+        "批量自选股分析 — 对多只股票并行采集行情/技术/资金/风险等数据，返回汇总结果。适用于每日定时分析自选股列表",
       parameters: {
         symbols: {
           type: "string",
@@ -749,7 +749,7 @@ export function apply(ctx: Context) {
     pyTool({
       name: "detect_anomaly",
       description:
-        "异常/事件检测 — 一键扫描股票当前所有异动信号（MACD金叉死叉、RSI超买超卖、20日突破、放量异动、涨跌停、布林突破、KDJ极值、资金异动等），返回结构化异常列表。“今天有什么异动/为什么大涨大跌”首选本工具；综合技术面判断用 get_technical_analysis",
+        "异常/事件检测 — 一键扫描股票当前所有异动信号（MACD金叉死叉、RSI超买超卖、20日突破、放量异动、涨跌停、布林突破、KDJ极值、资金异动等），返回结构化异常列表。当日异动归因的首选；综合技术面判断用 get_technical_analysis",
       parameters: {
         symbol: {
           type: "string",
@@ -884,7 +884,7 @@ export function apply(ctx: Context) {
     pyTool({
       name: "analyze_position_context",
       description:
-        "持仓上下文分析 — 输入成本/仓位/止损止盈，结合现价和技术位输出浮盈亏、离止损距离、风险级别、操作建议。“我XX成本买的被套了/要不要止损止盈”用本工具。无状态、不存账户",
+        "持仓上下文分析 — 输入成本/仓位/止损止盈，结合现价和技术位输出浮盈亏、离止损距离、风险级别、操作建议。无状态、不存账户",
       parameters: {
         symbol: { type: "string", required: true, description: "股票代码" },
         cost: { type: "number", required: true, description: "成本价" },
@@ -913,7 +913,7 @@ export function apply(ctx: Context) {
     pyTool({
       name: "check_alert_rules",
       description:
-        "无状态告警规则检查 — 传入规则数组，返回当前是否触发。规则类型：price_below/price_above/change_pct_above/change_pct_below/volume_ratio_above/anomaly/risk_veto/risk_level_at_least。“到价/涨跌幅提醒是否触发”用本工具。不做调度不存历史",
+        "无状态告警规则检查 — 传入规则数组，返回当前是否触发。规则类型：price_below/price_above/change_pct_above/change_pct_below/volume_ratio_above/anomaly/risk_veto/risk_level_at_least。不做调度不存历史",
       parameters: {
         symbol: { type: "string", required: true, description: "股票代码" },
         rules: {

--- a/hermes/schemas.py
+++ b/hermes/schemas.py
@@ -24,7 +24,7 @@ TOOL_SCHEMAS = [
     },
     {
         "name": "get_quote",
-        "description": "获取股票实时行情报价（现价、涨跌幅、量比等）。支持A股、港股、美股、日股、韩股、台股。问“现在多少钱/涨了多少”用本工具",
+        "description": "获取股票实时行情报价（现价、涨跌幅、量比等）。支持A股、港股、美股、日股、韩股、台股",
         "parameters": {
             "type": "object",
             "properties": {
@@ -38,7 +38,7 @@ TOOL_SCHEMAS = [
     },
     {
         "name": "get_capital_flow",
-        "description": "获取A股资金流向（主力/超大单/大单/中单/小单净流入）。detail=个股每日明细，summary=多日汇总+趋势，sector_flow=板块资金流排行。问“主力在买还是卖/资金流入流出”用本工具，可配合 get_chip_distribution 验证",
+        "description": "获取A股资金流向（主力/超大单/大单/中单/小单净流入）。detail=个股每日明细，summary=多日汇总+趋势，sector_flow=板块资金流排行。可配合 get_chip_distribution 验证主力行为",
         "parameters": {
             "type": "object",
             "properties": {
@@ -88,7 +88,7 @@ TOOL_SCHEMAS = [
     },
     {
         "name": "get_technical_analysis",
-        "description": "获取股票技术面分析（MA/MACD/RSI/BOLL/KDJ/成交量等指标 + 100分综合评分 + 6级买卖信号 + 趋势/偏离度/支撑压力位）。“能买吗/现在能入场吗/技术面怎么样”首选本工具；只要均线数值或自定义周期用 calculate_ma，专问量价用 get_volume_analysis，扫当日异动用 detect_anomaly",
+        "description": "获取股票技术面分析（MA/MACD/RSI/BOLL/KDJ/成交量等指标 + 100分综合评分 + 6级买卖信号 + 趋势/偏离度/支撑压力位）。个股技术面综合判断与买卖时机分析的首选；只要均线数值或自定义周期用 calculate_ma，专问量价用 get_volume_analysis，扫当日异动用 detect_anomaly",
         "parameters": {
             "type": "object",
             "properties": {
@@ -111,7 +111,7 @@ TOOL_SCHEMAS = [
     },
     {
         "name": "analyze_pattern",
-        "description": "K线形态识别 — 检测十字星、锤子线、吞没、启明星、黄昏星、双底、20日突破等12+种经典形态。问“出现了什么形态”时用；综合技术面判断用 get_technical_analysis",
+        "description": "K线形态识别 — 检测十字星、锤子线、吞没、启明星、黄昏星、双底、20日突破等12+种经典形态。综合技术面判断用 get_technical_analysis",
         "parameters": {
             "type": "object",
             "properties": {
@@ -134,7 +134,7 @@ TOOL_SCHEMAS = [
     },
     {
         "name": "get_market_indices",
-        "description": "获取主要市场指数行情。CN: 上证/深证/创业板/科创50/沪深300；HK: 恒生/国企/科技；US: 道琼斯/纳斯达克/标普500；JP: 日经225/东证；KR: KOSPI/KOSDAQ；TW: 台湾加权。“复盘今天大盘”用 get_market_review 一站式获取",
+        "description": "获取主要市场指数行情。CN: 上证/深证/创业板/科创50/沪深300；HK: 恒生/国企/科技；US: 道琼斯/纳斯达克/标普500；JP: 日经225/东证；KR: KOSPI/KOSDAQ；TW: 台湾加权。大盘复盘用 get_market_review 一站式获取",
         "parameters": {
             "type": "object",
             "properties": {
@@ -148,7 +148,7 @@ TOOL_SCHEMAS = [
     },
     {
         "name": "get_sector_rankings",
-        "description": "获取A股行业板块涨跌幅排行（含领涨股、涨跌家数等）。支持查看涨幅榜/跌幅榜/双向。找热点板块/领涨板块用本工具",
+        "description": "获取A股行业板块涨跌幅排行（含领涨股、涨跌家数等）。支持查看涨幅榜/跌幅榜/双向",
         "parameters": {
             "type": "object",
             "properties": {
@@ -194,7 +194,7 @@ TOOL_SCHEMAS = [
     },
     {
         "name": "get_market_stats",
-        "description": "获取A股市场整体统计（涨跌家数、涨停跌停数、平均涨幅、涨跌Top5、总成交额）。问“今天市场情绪/温度如何”用本工具",
+        "description": "获取A股市场整体统计（涨跌家数、涨停跌停数、平均涨幅、涨跌Top5、总成交额）。用于衡量市场整体情绪与温度",
         "parameters": {
             "type": "object",
             "properties": {
@@ -208,7 +208,7 @@ TOOL_SCHEMAS = [
     },
     {
         "name": "get_fundamental_context",
-        "description": "获取A股深度基本面（估值PE/PB/PS + 成长性营收/净利增速 + 盈利能力ROE/毛利率 + 分红历史）。“公司质地如何/能不能长期持有”用本工具；快速查PE/PB用 get_financials",
+        "description": "获取A股深度基本面（估值PE/PB/PS + 成长性营收/净利增速 + 盈利能力ROE/毛利率 + 分红历史）。用于评估公司质地与长期持有价值；快速查PE/PB用 get_financials",
         "parameters": {
             "type": "object",
             "properties": {
@@ -222,7 +222,7 @@ TOOL_SCHEMAS = [
     },
     {
         "name": "screen_stocks",
-        "description": "全市场股票筛选（AlphaSift L1 多因子硬筛）。按PE/PB/市值/换手率/涨跌幅/量比等因子过滤和评分。“帮我选股/筛选低估值/高换手股票”用本工具",
+        "description": "全市场股票筛选（AlphaSift L1 多因子硬筛）。按PE/PB/市值/换手率/涨跌幅/量比等因子过滤和评分",
         "parameters": {
             "type": "object",
             "properties": {
@@ -274,7 +274,7 @@ TOOL_SCHEMAS = [
     },
     {
         "name": "evaluate_signal",
-        "description": "技术信号历史准确率评估 — 回溯历史数据，统计某个技术信号触发后N日的胜率和平均收益。支持9种信号：macd_golden_cross/macd_death_cross/rsi_oversold/rsi_overbought/breakout_20d/breakdown_20d/volume_surge/ma_golden_cross/ma_death_cross。“金叉/突破策略靠不靠谱”用本工具；要完整模拟交易过程用 run_backtest",
+        "description": "技术信号历史准确率评估 — 回溯历史数据，统计某个技术信号触发后N日的胜率和平均收益。支持9种信号：macd_golden_cross/macd_death_cross/rsi_oversold/rsi_overbought/breakout_20d/breakdown_20d/volume_surge/ma_golden_cross/ma_death_cross。要完整模拟交易过程用 run_backtest",
         "parameters": {
             "type": "object",
             "properties": {
@@ -399,7 +399,7 @@ TOOL_SCHEMAS = [
     },
     {
         "name": "get_volume_analysis",
-        "description": "独立量价分析 — 量价相关性、上涨/下跌日成交量对比、量能趋势、量价模式解读（放量上涨/缩量回调等）。专问量能/量价配合时用本工具；综合技术面判断用 get_technical_analysis，扫当日异动用 detect_anomaly",
+        "description": "独立量价分析 — 量价相关性、上涨/下跌日成交量对比、量能趋势、量价模式解读（放量上涨/缩量回调等）。综合技术面判断用 get_technical_analysis，扫当日异动用 detect_anomaly",
         "parameters": {
             "type": "object",
             "properties": {
@@ -440,7 +440,7 @@ TOOL_SCHEMAS = [
     },
     {
         "name": "search_comprehensive_intel",
-        "description": "股票综合情报搜索 — 从6个维度（新闻/公告/行情分析/风险/业绩/行业）搜索综合信息。“深入研究/全面调研这家公司”用本工具；快速看新闻用 get_news",
+        "description": "股票综合情报搜索 — 从6个维度（新闻/公告/行情分析/风险/业绩/行业）搜索综合信息。用于个股的深入研究/全面调研；快速看新闻用 get_news",
         "parameters": {
             "type": "object",
             "properties": {
@@ -458,7 +458,7 @@ TOOL_SCHEMAS = [
     },
     {
         "name": "get_social_sentiment",
-        "description": "获取股票社交媒体情绪数据。A股：东方财富股吧热度+雪球讨论热度（无需配置）；美股/港股：Reddit/X/Polymarket情绪（需 SENTIMENT_API_KEY）。自动按市场选数据源。“散户在讨论什么/情绪如何”用本工具；看全市场热门讨论用 get_trending_sentiment",
+        "description": "获取股票社交媒体情绪数据。A股：东方财富股吧热度+雪球讨论热度（无需配置）；美股/港股：Reddit/X/Polymarket情绪（需 SENTIMENT_API_KEY）。自动按市场选数据源。面向个股维度；全市场热门讨论用 get_trending_sentiment",
         "parameters": {
             "type": "object",
             "properties": {
@@ -472,7 +472,7 @@ TOOL_SCHEMAS = [
     },
     {
         "name": "get_trending_sentiment",
-        "description": "获取社交媒体热门趋势（Reddit/X/Polymarket热门股票讨论）。数据缓存10分钟。“现在市场热点是什么/大家都在买什么”用本工具；查个股情绪用 get_social_sentiment",
+        "description": "获取社交媒体热门趋势（Reddit/X/Polymarket热门股票讨论）。数据缓存10分钟。适用于发现市场热点；查个股情绪用 get_social_sentiment",
         "parameters": {
             "type": "object",
             "properties": {},
@@ -494,7 +494,7 @@ TOOL_SCHEMAS = [
     },
     {
         "name": "screen_risk",
-        "description": "风险专项筛查 — 7维度风险检测（估值极端/技术预警/解禁到期/内部人减持/业绩预警/监管处罚/行业政策），返回风险评级和一票否决标记。“这股票有什么雷”用本工具；入场决策前排雷必调",
+        "description": "风险专项筛查 — 7维度风险检测（估值极端/技术预警/解禁到期/内部人减持/业绩预警/监管处罚/行业政策），返回风险评级和一票否决标记。入场决策前的排雷必调本工具",
         "parameters": {
             "type": "object",
             "properties": {
@@ -512,7 +512,7 @@ TOOL_SCHEMAS = [
     },
     {
         "name": "detect_market_regime",
-        "description": "市场状态检测 — 分析大盘指数判断当前市场阶段（上涨趋势/下跌趋势/横盘震荡/高波动/板块热点），并推荐适合的分析策略。“现在大盘能进场吗/该用什么策略”用本工具",
+        "description": "市场状态检测 — 分析大盘指数判断当前市场阶段（上涨趋势/下跌趋势/横盘震荡/高波动/板块热点），并推荐适合的分析策略",
         "parameters": {
             "type": "object",
             "properties": {
@@ -526,7 +526,7 @@ TOOL_SCHEMAS = [
     },
     {
         "name": "get_market_review",
-        "description": "大盘复盘 — 获取市场日度复盘数据，包含指数、涨跌统计、板块排名、新闻、市场温度与策略建议。“复盘一下今天市场/今天大盘怎么样”首选本工具，无需再分别调指数/统计/板块工具",
+        "description": "大盘复盘 — 获取市场日度复盘数据，包含指数、涨跌统计、板块排名、新闻、市场温度与策略建议。复盘类需求的首选，无需再分别调指数/统计/板块工具",
         "parameters": {
             "type": "object",
             "properties": {
@@ -540,7 +540,7 @@ TOOL_SCHEMAS = [
     },
     {
         "name": "run_watchlist_analysis",
-        "description": "批量自选股分析 — 对多只股票并行采集行情/技术/资金/风险等数据，返回汇总结果。“批量分析我的自选股”/每日定时分析用本工具",
+        "description": "批量自选股分析 — 对多只股票并行采集行情/技术/资金/风险等数据，返回汇总结果。适用于每日定时分析自选股列表",
         "parameters": {
             "type": "object",
             "properties": {
@@ -558,7 +558,7 @@ TOOL_SCHEMAS = [
     },
     {
         "name": "detect_anomaly",
-        "description": "异常/事件检测 — 一键扫描股票当前所有异动信号（MACD金叉死叉、RSI超买超卖、20日突破、放量异动、涨跌停、布林突破、KDJ极值、资金异动等），返回结构化异常列表。“今天有什么异动/为什么大涨大跌”首选本工具；综合技术面判断用 get_technical_analysis",
+        "description": "异常/事件检测 — 一键扫描股票当前所有异动信号（MACD金叉死叉、RSI超买超卖、20日突破、放量异动、涨跌停、布林突破、KDJ极值、资金异动等），返回结构化异常列表。当日异动归因的首选；综合技术面判断用 get_technical_analysis",
         "parameters": {
             "type": "object",
             "properties": {
@@ -634,7 +634,7 @@ TOOL_SCHEMAS = [
     },
     {
         "name": "analyze_position_context",
-        "description": "持仓上下文分析 — 输入成本/仓位/止损止盈，结合现价和技术位输出浮盈亏、离止损距离、风险级别、操作建议。“我XX成本买的被套了/要不要止损止盈”用本工具。无状态、不存账户",
+        "description": "持仓上下文分析 — 输入成本/仓位/止损止盈，结合现价和技术位输出浮盈亏、离止损距离、风险级别、操作建议。无状态、不存账户",
         "parameters": {
             "type": "object",
             "properties": {
@@ -649,7 +649,7 @@ TOOL_SCHEMAS = [
     },
     {
         "name": "check_alert_rules",
-        "description": "无状态告警规则检查 — 传入规则数组，返回当前是否触发。规则类型：price_below/price_above/change_pct_above/change_pct_below/volume_ratio_above/anomaly/risk_veto/risk_level_at_least。“到价/涨跌幅提醒是否触发”用本工具。不做调度不存历史",
+        "description": "无状态告警规则检查 — 传入规则数组，返回当前是否触发。规则类型：price_below/price_above/change_pct_above/change_pct_below/volume_ratio_above/anomaly/risk_veto/risk_level_at_least。不做调度不存历史",
         "parameters": {
             "type": "object",
             "properties": {

--- a/hermes/schemas.py
+++ b/hermes/schemas.py
@@ -1,7 +1,7 @@
 TOOL_SCHEMAS = [
     {
         "name": "get_kline",
-        "description": "获取股票K线数据（OHLCV）。支持A股（如600519）、港股（如00700.HK）、美股（如AAPL）、日股（如7203.T）、韩股（如005930.KS）、台股（如2330.TW）及A股ETF",
+        "description": "获取股票K线数据（OHLCV）。支持A股（如600519）、港股（如00700.HK）、美股（如AAPL）、日股（如7203.T）、韩股（如005930.KS）、台股（如2330.TW）及A股ETF。需要原始历史价格自行计算或画图时用；只问指标用 get_technical_analysis，只问现价用 get_quote",
         "parameters": {
             "type": "object",
             "properties": {
@@ -24,7 +24,7 @@ TOOL_SCHEMAS = [
     },
     {
         "name": "get_quote",
-        "description": "获取股票实时行情报价。支持A股、港股、美股、日股、韩股、台股",
+        "description": "获取股票实时行情报价（现价、涨跌幅、量比等）。支持A股、港股、美股、日股、韩股、台股。问“现在多少钱/涨了多少”用本工具",
         "parameters": {
             "type": "object",
             "properties": {
@@ -38,7 +38,7 @@ TOOL_SCHEMAS = [
     },
     {
         "name": "get_capital_flow",
-        "description": "获取A股资金流向数据。detail=个股每日明细，summary=多日汇总+趋势，sector_flow=板块资金流排行",
+        "description": "获取A股资金流向（主力/超大单/大单/中单/小单净流入）。detail=个股每日明细，summary=多日汇总+趋势，sector_flow=板块资金流排行。问“主力在买还是卖/资金流入流出”用本工具，可配合 get_chip_distribution 验证",
         "parameters": {
             "type": "object",
             "properties": {
@@ -56,7 +56,7 @@ TOOL_SCHEMAS = [
     },
     {
         "name": "get_news",
-        "description": "获取股票相关财经新闻",
+        "description": "获取个股最近N天财经新闻快讯（轻量、无需配置）。需要深度全网情报用 search_comprehensive_intel，按主题搜索用 search_stock_news，读文章全文用 extract_article",
         "parameters": {
             "type": "object",
             "properties": {
@@ -74,7 +74,7 @@ TOOL_SCHEMAS = [
     },
     {
         "name": "get_financials",
-        "description": "获取股票关键财务指标（PE/PB/市值/营收/净利润/ROE等）",
+        "description": "获取股票关键财务指标（PE/PB/市值/营收/净利润/ROE等），适合快速估值快查。A股深度基本面（成长性/盈利能力/分红）用 get_fundamental_context",
         "parameters": {
             "type": "object",
             "properties": {
@@ -88,7 +88,7 @@ TOOL_SCHEMAS = [
     },
     {
         "name": "get_technical_analysis",
-        "description": "获取股票技术面分析（MA/MACD/RSI/BOLL/KDJ/成交量等指标 + 100分综合评分 + 6级买卖信号 + 趋势/偏离度/支撑压力位）",
+        "description": "获取股票技术面分析（MA/MACD/RSI/BOLL/KDJ/成交量等指标 + 100分综合评分 + 6级买卖信号 + 趋势/偏离度/支撑压力位）。“能买吗/现在能入场吗/技术面怎么样”首选本工具；只要均线数值或自定义周期用 calculate_ma，专问量价用 get_volume_analysis，扫当日异动用 detect_anomaly",
         "parameters": {
             "type": "object",
             "properties": {
@@ -111,7 +111,7 @@ TOOL_SCHEMAS = [
     },
     {
         "name": "analyze_pattern",
-        "description": "K线形态识别 — 检测十字星、锤子线、吞没、启明星、黄昏星、双底、20日突破等12+种经典形态",
+        "description": "K线形态识别 — 检测十字星、锤子线、吞没、启明星、黄昏星、双底、20日突破等12+种经典形态。问“出现了什么形态”时用；综合技术面判断用 get_technical_analysis",
         "parameters": {
             "type": "object",
             "properties": {
@@ -134,7 +134,7 @@ TOOL_SCHEMAS = [
     },
     {
         "name": "get_market_indices",
-        "description": "获取主要市场指数行情。CN: 上证/深证/创业板/科创50/沪深300；HK: 恒生/国企/科技；US: 道琼斯/纳斯达克/标普500；JP: 日经225/东证；KR: KOSPI/KOSDAQ；TW: 台湾加权",
+        "description": "获取主要市场指数行情。CN: 上证/深证/创业板/科创50/沪深300；HK: 恒生/国企/科技；US: 道琼斯/纳斯达克/标普500；JP: 日经225/东证；KR: KOSPI/KOSDAQ；TW: 台湾加权。“复盘今天大盘”用 get_market_review 一站式获取",
         "parameters": {
             "type": "object",
             "properties": {
@@ -148,7 +148,7 @@ TOOL_SCHEMAS = [
     },
     {
         "name": "get_sector_rankings",
-        "description": "获取A股行业板块涨跌幅排行（含领涨股、涨跌家数等）。支持查看涨幅榜/跌幅榜/双向",
+        "description": "获取A股行业板块涨跌幅排行（含领涨股、涨跌家数等）。支持查看涨幅榜/跌幅榜/双向。找热点板块/领涨板块用本工具",
         "parameters": {
             "type": "object",
             "properties": {
@@ -180,7 +180,7 @@ TOOL_SCHEMAS = [
     },
     {
         "name": "get_chip_distribution",
-        "description": "获取A股筹码分布数据（获利比例、平均成本、90%/70%成本集中度）。仅支持A股",
+        "description": "获取A股筹码分布数据（获利比例、平均成本、90%/70%成本集中度）。仅支持A股。与 get_capital_flow 配合验证主力行为",
         "parameters": {
             "type": "object",
             "properties": {
@@ -194,7 +194,7 @@ TOOL_SCHEMAS = [
     },
     {
         "name": "get_market_stats",
-        "description": "获取A股市场整体统计（涨跌家数、涨停跌停数、平均涨幅、涨跌Top5、总成交额）",
+        "description": "获取A股市场整体统计（涨跌家数、涨停跌停数、平均涨幅、涨跌Top5、总成交额）。问“今天市场情绪/温度如何”用本工具",
         "parameters": {
             "type": "object",
             "properties": {
@@ -208,7 +208,7 @@ TOOL_SCHEMAS = [
     },
     {
         "name": "get_fundamental_context",
-        "description": "获取A股深度基本面（估值PE/PB/PS + 成长性营收/净利增速 + 盈利能力ROE/毛利率 + 分红历史）",
+        "description": "获取A股深度基本面（估值PE/PB/PS + 成长性营收/净利增速 + 盈利能力ROE/毛利率 + 分红历史）。“公司质地如何/能不能长期持有”用本工具；快速查PE/PB用 get_financials",
         "parameters": {
             "type": "object",
             "properties": {
@@ -222,7 +222,7 @@ TOOL_SCHEMAS = [
     },
     {
         "name": "screen_stocks",
-        "description": "全市场股票筛选（AlphaSift L1 多因子硬筛）。按PE/PB/市值/换手率/涨跌幅/量比等因子过滤和评分",
+        "description": "全市场股票筛选（AlphaSift L1 多因子硬筛）。按PE/PB/市值/换手率/涨跌幅/量比等因子过滤和评分。“帮我选股/筛选低估值/高换手股票”用本工具",
         "parameters": {
             "type": "object",
             "properties": {
@@ -244,7 +244,7 @@ TOOL_SCHEMAS = [
     },
     {
         "name": "run_backtest",
-        "description": "策略回测（AlphaEvo）。读取YAML策略定义，在历史数据上模拟交易，输出收益率/回撤/胜率等指标",
+        "description": "策略回测（AlphaEvo）。读取YAML策略定义，在历史数据上模拟交易，输出收益率/回撤/胜率等指标。只想知道单个技术信号的历史胜率用更轻量的 evaluate_signal",
         "parameters": {
             "type": "object",
             "properties": {
@@ -274,7 +274,7 @@ TOOL_SCHEMAS = [
     },
     {
         "name": "evaluate_signal",
-        "description": "技术信号历史准确率评估 — 回溯历史数据，统计某个技术信号触发后N日的胜率和平均收益。支持9种信号：macd_golden_cross/macd_death_cross/rsi_oversold/rsi_overbought/breakout_20d/breakdown_20d/volume_surge/ma_golden_cross/ma_death_cross",
+        "description": "技术信号历史准确率评估 — 回溯历史数据，统计某个技术信号触发后N日的胜率和平均收益。支持9种信号：macd_golden_cross/macd_death_cross/rsi_oversold/rsi_overbought/breakout_20d/breakdown_20d/volume_surge/ma_golden_cross/ma_death_cross。“金叉/突破策略靠不靠谱”用本工具；要完整模拟交易过程用 run_backtest",
         "parameters": {
             "type": "object",
             "properties": {
@@ -311,7 +311,7 @@ TOOL_SCHEMAS = [
     },
     {
         "name": "resolve_stock_name",
-        "description": "股票名称智能解析 — 输入中文名（贵州茅台）、拼音（guizhou maotai/gzmt）、部分代码，返回匹配的股票代码。仅支持A股",
+        "description": "股票名称智能解析 — 输入中文名（贵州茅台）、拼音（guizhou maotai/gzmt）、部分代码，返回匹配的股票代码。仅支持A股。用户给出中文名/拼音/部分代码时先调本工具换成代码再调其他工具",
         "parameters": {
             "type": "object",
             "properties": {
@@ -376,7 +376,7 @@ TOOL_SCHEMAS = [
     },
     {
         "name": "calculate_ma",
-        "description": "独立均线计算器 — 支持任意周期MA（5/10/20/30/60/120/250或自定义）+ 偏离度 + 均线排列 + 金叉死叉检测",
+        "description": "独立均线计算器 — 支持任意周期MA（5/10/20/30/60/120/250或自定义）+ 偏离度 + 均线排列 + 金叉死叉检测。只要均线数值或需要30/120/250等非默认周期时用本工具；综合技术面分析用 get_technical_analysis",
         "parameters": {
             "type": "object",
             "properties": {
@@ -399,7 +399,7 @@ TOOL_SCHEMAS = [
     },
     {
         "name": "get_volume_analysis",
-        "description": "独立量价分析 — 量价相关性、上涨/下跌日成交量对比、量能趋势、量价模式解读（放量上涨/缩量回调等）",
+        "description": "独立量价分析 — 量价相关性、上涨/下跌日成交量对比、量能趋势、量价模式解读（放量上涨/缩量回调等）。专问量能/量价配合时用本工具；综合技术面判断用 get_technical_analysis，扫当日异动用 detect_anomaly",
         "parameters": {
             "type": "object",
             "properties": {
@@ -422,7 +422,7 @@ TOOL_SCHEMAS = [
     },
     {
         "name": "search_stock_news",
-        "description": "多引擎股票新闻搜索（支持 Tavily/Brave/SerpAPI）。需配置对应 API Key 环境变量",
+        "description": "多引擎股票新闻搜索（支持 Tavily/Brave/SerpAPI）。需配置对应 API Key 环境变量。get_news 快讯不够或要按主题搜索时用本工具；深度6维情报用 search_comprehensive_intel",
         "parameters": {
             "type": "object",
             "properties": {
@@ -440,7 +440,7 @@ TOOL_SCHEMAS = [
     },
     {
         "name": "search_comprehensive_intel",
-        "description": "股票综合情报搜索 — 从6个维度（新闻/公告/行情分析/风险/业绩/行业）搜索综合信息",
+        "description": "股票综合情报搜索 — 从6个维度（新闻/公告/行情分析/风险/业绩/行业）搜索综合信息。“深入研究/全面调研这家公司”用本工具；快速看新闻用 get_news",
         "parameters": {
             "type": "object",
             "properties": {
@@ -458,7 +458,7 @@ TOOL_SCHEMAS = [
     },
     {
         "name": "get_social_sentiment",
-        "description": "获取股票社交媒体情绪数据。A股：东方财富股吧热度+雪球讨论热度；美股/港股：Reddit/X/Polymarket情绪。自动根据市场选择数据源",
+        "description": "获取股票社交媒体情绪数据。A股：东方财富股吧热度+雪球讨论热度（无需配置）；美股/港股：Reddit/X/Polymarket情绪（需 SENTIMENT_API_KEY）。自动按市场选数据源。“散户在讨论什么/情绪如何”用本工具；看全市场热门讨论用 get_trending_sentiment",
         "parameters": {
             "type": "object",
             "properties": {
@@ -472,7 +472,7 @@ TOOL_SCHEMAS = [
     },
     {
         "name": "get_trending_sentiment",
-        "description": "获取社交媒体热门趋势（Reddit/X/Polymarket热门股票讨论）。数据缓存10分钟。适用于发现市场热点",
+        "description": "获取社交媒体热门趋势（Reddit/X/Polymarket热门股票讨论）。数据缓存10分钟。“现在市场热点是什么/大家都在买什么”用本工具；查个股情绪用 get_social_sentiment",
         "parameters": {
             "type": "object",
             "properties": {},
@@ -480,7 +480,7 @@ TOOL_SCHEMAS = [
     },
     {
         "name": "extract_article",
-        "description": "网页文章全文提取 — 输入URL，提取文章标题、正文（最多3000字）、作者、发布日期等。适用于深度阅读搜索结果中的新闻/研报",
+        "description": "网页文章全文提取 — 输入URL，提取文章标题、正文（最多3000字）、作者、发布日期等。配合 get_news/search_stock_news 的搜索结果做深度阅读",
         "parameters": {
             "type": "object",
             "properties": {
@@ -494,7 +494,7 @@ TOOL_SCHEMAS = [
     },
     {
         "name": "screen_risk",
-        "description": "风险专项筛查 — 7维度风险检测（估值极端/技术预警/解禁到期/内部人减持/业绩预警/监管处罚/行业政策），返回风险评级和一票否决标记",
+        "description": "风险专项筛查 — 7维度风险检测（估值极端/技术预警/解禁到期/内部人减持/业绩预警/监管处罚/行业政策），返回风险评级和一票否决标记。“这股票有什么雷”用本工具；入场决策前排雷必调",
         "parameters": {
             "type": "object",
             "properties": {
@@ -512,7 +512,7 @@ TOOL_SCHEMAS = [
     },
     {
         "name": "detect_market_regime",
-        "description": "市场状态检测 — 分析大盘指数判断当前市场阶段（上涨趋势/下跌趋势/横盘震荡/高波动/板块热点），并推荐适合的分析策略",
+        "description": "市场状态检测 — 分析大盘指数判断当前市场阶段（上涨趋势/下跌趋势/横盘震荡/高波动/板块热点），并推荐适合的分析策略。“现在大盘能进场吗/该用什么策略”用本工具",
         "parameters": {
             "type": "object",
             "properties": {
@@ -526,7 +526,7 @@ TOOL_SCHEMAS = [
     },
     {
         "name": "get_market_review",
-        "description": "大盘复盘 — 获取市场日度复盘数据，包含指数表现、涨跌统计、板块排名、重要新闻、市场温度与策略建议",
+        "description": "大盘复盘 — 获取市场日度复盘数据，包含指数、涨跌统计、板块排名、新闻、市场温度与策略建议。“复盘一下今天市场/今天大盘怎么样”首选本工具，无需再分别调指数/统计/板块工具",
         "parameters": {
             "type": "object",
             "properties": {
@@ -540,7 +540,7 @@ TOOL_SCHEMAS = [
     },
     {
         "name": "run_watchlist_analysis",
-        "description": "批量自选股分析 — 对多只股票并行采集行情/技术/资金/风险等数据，返回汇总结果。适用于每日定时分析自选股列表",
+        "description": "批量自选股分析 — 对多只股票并行采集行情/技术/资金/风险等数据，返回汇总结果。“批量分析我的自选股”/每日定时分析用本工具",
         "parameters": {
             "type": "object",
             "properties": {
@@ -558,7 +558,7 @@ TOOL_SCHEMAS = [
     },
     {
         "name": "detect_anomaly",
-        "description": "异常/事件检测 — 一键扫描股票当前所有异动信号（MACD金叉死叉、RSI超买超卖、20日突破、放量异动、涨跌停、布林突破、KDJ极值、资金异动等），返回结构化异常列表",
+        "description": "异常/事件检测 — 一键扫描股票当前所有异动信号（MACD金叉死叉、RSI超买超卖、20日突破、放量异动、涨跌停、布林突破、KDJ极值、资金异动等），返回结构化异常列表。“今天有什么异动/为什么大涨大跌”首选本工具；综合技术面判断用 get_technical_analysis",
         "parameters": {
             "type": "object",
             "properties": {
@@ -572,7 +572,7 @@ TOOL_SCHEMAS = [
     },
     {
         "name": "diagnose_data_sources",
-        "description": "数据源诊断 — 检查当前环境可用的数据 provider（akshare/tushare/yfinance/finnhub/longbridge/alphavantage），输出每个市场的可用链路、缺失 env、warnings。用于让 agent 自解释为何拿不到数据",
+        "description": "数据源诊断 — 检查当前环境可用的数据 provider（akshare/tushare/yfinance/finnhub/longbridge/alphavantage），输出每个市场的可用链路、缺失 env、warnings。工具拿不到数据或报错时调用排查",
         "parameters": {
             "type": "object",
             "properties": {
@@ -586,7 +586,7 @@ TOOL_SCHEMAS = [
     },
     {
         "name": "get_market_capabilities",
-        "description": "市场能力边界 — 返回指定市场支持/不支持的工具列表，避免 agent 对港股调 get_chip_distribution 或对美股调 get_capital_flow 后编造数据",
+        "description": "市场能力边界 — 返回指定市场支持/不支持的工具列表。不确定某市场能否用某工具（如港股的筹码分布、美股的资金流）时先调本工具，避免调用不支持的工具后编造数据",
         "parameters": {
             "type": "object",
             "properties": {
@@ -597,7 +597,7 @@ TOOL_SCHEMAS = [
     },
     {
         "name": "render_stock_report",
-        "description": "股票分析报告渲染 — 将结构化 JSON（符合 schemas/report_schema.json）通过 j2 模板渲染为 Markdown。template: brief|full。仅渲染，不保存不推送",
+        "description": "股票分析报告渲染 — 将结构化 JSON（符合 schemas/report_schema.json）通过 j2 模板渲染为 Markdown。template: brief|full。全部分析完成后的最后一步调用。仅渲染，不保存不推送",
         "parameters": {
             "type": "object",
             "properties": {
@@ -634,7 +634,7 @@ TOOL_SCHEMAS = [
     },
     {
         "name": "analyze_position_context",
-        "description": "持仓上下文分析 — 输入成本/仓位/止损止盈，结合现价和技术位输出浮盈亏、离止损距离、风险级别、操作建议。无状态、不存账户",
+        "description": "持仓上下文分析 — 输入成本/仓位/止损止盈，结合现价和技术位输出浮盈亏、离止损距离、风险级别、操作建议。“我XX成本买的被套了/要不要止损止盈”用本工具。无状态、不存账户",
         "parameters": {
             "type": "object",
             "properties": {
@@ -649,7 +649,7 @@ TOOL_SCHEMAS = [
     },
     {
         "name": "check_alert_rules",
-        "description": "无状态告警规则检查 — 传入规则数组，返回当前是否触发。规则类型：price_below/price_above/change_pct_above/change_pct_below/volume_ratio_above/anomaly/risk_veto/risk_level_at_least。不做调度不存历史",
+        "description": "无状态告警规则检查 — 传入规则数组，返回当前是否触发。规则类型：price_below/price_above/change_pct_above/change_pct_below/volume_ratio_above/anomaly/risk_veto/risk_level_at_least。“到价/涨跌幅提醒是否触发”用本工具。不做调度不存历史",
         "parameters": {
             "type": "object",
             "properties": {

--- a/openclaw/index.ts
+++ b/openclaw/index.ts
@@ -88,7 +88,7 @@ export default definePluginEntry({
 
     api.registerTool({
       name: "get_quote",
-      description: "获取股票实时行情报价（现价、涨跌幅、量比等）。支持A股、港股、美股、日股、韩股、台股。问“现在多少钱/涨了多少”用本工具",
+      description: "获取股票实时行情报价（现价、涨跌幅、量比等）。支持A股、港股、美股、日股、韩股、台股",
       parameters: Type.Object({
         symbol: Type.String({ description: "股票代码" }),
       }),
@@ -101,7 +101,7 @@ export default definePluginEntry({
     api.registerTool({
       name: "get_capital_flow",
       description:
-        "获取A股资金流向（主力/超大单/大单/中单/小单净流入）。detail=个股每日明细，summary=多日汇总+趋势，sector_flow=板块资金流排行。问“主力在买还是卖/资金流入流出”用本工具，可配合 get_chip_distribution 验证",
+        "获取A股资金流向（主力/超大单/大单/中单/小单净流入）。detail=个股每日明细，summary=多日汇总+趋势，sector_flow=板块资金流排行。可配合 get_chip_distribution 验证主力行为",
       parameters: Type.Object({
         symbol: Type.Optional(
           Type.String({ description: "A股股票代码（detail/summary模式必填），如 600519" })
@@ -163,7 +163,7 @@ export default definePluginEntry({
     api.registerTool({
       name: "get_technical_analysis",
       description:
-        "获取股票技术面分析（MA/MACD/RSI/BOLL/KDJ/成交量等指标 + 100分综合评分 + 6级买卖信号 + 趋势/偏离度/支撑压力位）。“能买吗/现在能入场吗/技术面怎么样”首选本工具；只要均线数值或自定义周期用 calculate_ma，专问量价用 get_volume_analysis，扫当日异动用 detect_anomaly",
+        "获取股票技术面分析（MA/MACD/RSI/BOLL/KDJ/成交量等指标 + 100分综合评分 + 6级买卖信号 + 趋势/偏离度/支撑压力位）。个股技术面综合判断与买卖时机分析的首选；只要均线数值或自定义周期用 calculate_ma，专问量价用 get_volume_analysis，扫当日异动用 detect_anomaly",
       parameters: Type.Object({
         symbol: Type.String({ description: "股票代码" }),
         period: Type.Optional(
@@ -192,7 +192,7 @@ export default definePluginEntry({
     api.registerTool({
       name: "analyze_pattern",
       description:
-        "K线形态识别 — 检测十字星、锤子线、吞没、启明星、黄昏星、双底、20日突破等12+种经典形态。问“出现了什么形态”时用；综合技术面判断用 get_technical_analysis",
+        "K线形态识别 — 检测十字星、锤子线、吞没、启明星、黄昏星、双底、20日突破等12+种经典形态。综合技术面判断用 get_technical_analysis",
       parameters: Type.Object({
         symbol: Type.String({ description: "股票代码" }),
         period: Type.Optional(
@@ -223,7 +223,7 @@ export default definePluginEntry({
     api.registerTool({
       name: "get_market_indices",
       description:
-        "获取主要市场指数行情。CN: 上证/深证/创业板/科创50/沪深300；HK: 恒生/国企/科技；US: 道琼斯/纳斯达克/标普500；JP: 日经225/东证；KR: KOSPI/KOSDAQ；TW: 台湾加权。“复盘今天大盘”用 get_market_review 一站式获取",
+        "获取主要市场指数行情。CN: 上证/深证/创业板/科创50/沪深300；HK: 恒生/国企/科技；US: 道琼斯/纳斯达克/标普500；JP: 日经225/东证；KR: KOSPI/KOSDAQ；TW: 台湾加权。大盘复盘用 get_market_review 一站式获取",
       parameters: Type.Object({
         region: Type.Optional(
           Type.Union(
@@ -245,7 +245,7 @@ export default definePluginEntry({
     api.registerTool({
       name: "get_sector_rankings",
       description:
-        "获取A股行业板块涨跌幅排行（含领涨股、涨跌家数等）。支持查看涨幅榜/跌幅榜/双向。找热点板块/领涨板块用本工具",
+        "获取A股行业板块涨跌幅排行（含领涨股、涨跌家数等）。支持查看涨幅榜/跌幅榜/双向",
       parameters: Type.Object({
         top: Type.Optional(
           Type.Number({ description: "返回排名前N的板块，默认 10" })
@@ -301,7 +301,7 @@ export default definePluginEntry({
     api.registerTool({
       name: "get_market_stats",
       description:
-        "获取A股市场整体统计（涨跌家数、涨停跌停数、平均涨幅、涨跌Top5、总成交额）。问“今天市场情绪/温度如何”用本工具",
+        "获取A股市场整体统计（涨跌家数、涨停跌停数、平均涨幅、涨跌Top5、总成交额）。用于衡量市场整体情绪与温度",
       parameters: Type.Object({
         market: Type.Optional(
           Type.Union([Type.Literal("A")], { description: "市场，目前仅支持 A" })
@@ -320,7 +320,7 @@ export default definePluginEntry({
     api.registerTool({
       name: "get_fundamental_context",
       description:
-        "获取A股深度基本面（估值PE/PB/PS + 成长性营收/净利增速 + 盈利能力ROE/毛利率 + 分红历史）。“公司质地如何/能不能长期持有”用本工具；快速查PE/PB用 get_financials",
+        "获取A股深度基本面（估值PE/PB/PS + 成长性营收/净利增速 + 盈利能力ROE/毛利率 + 分红历史）。用于评估公司质地与长期持有价值；快速查PE/PB用 get_financials",
       parameters: Type.Object({
         symbol: Type.String({ description: "A股股票代码，如 600519" }),
       }),
@@ -338,7 +338,7 @@ export default definePluginEntry({
     api.registerTool({
       name: "screen_stocks",
       description:
-        "全市场股票筛选（AlphaSift L1 多因子硬筛）。按PE/PB/市值/换手率/涨跌幅/量比等因子过滤和评分。“帮我选股/筛选低估值/高换手股票”用本工具",
+        "全市场股票筛选（AlphaSift L1 多因子硬筛）。按PE/PB/市值/换手率/涨跌幅/量比等因子过滤和评分",
       parameters: Type.Object({
         market: Type.Optional(
           Type.Union(
@@ -397,7 +397,7 @@ export default definePluginEntry({
     api.registerTool({
       name: "evaluate_signal",
       description:
-        "技术信号历史准确率评估 — 回溯历史数据，统计某个技术信号触发后N日的胜率和平均收益。支持9种信号：macd_golden_cross/macd_death_cross/rsi_oversold/rsi_overbought/breakout_20d/breakdown_20d/volume_surge/ma_golden_cross/ma_death_cross。“金叉/突破策略靠不靠谱”用本工具；要完整模拟交易过程用 run_backtest",
+        "技术信号历史准确率评估 — 回溯历史数据，统计某个技术信号触发后N日的胜率和平均收益。支持9种信号：macd_golden_cross/macd_death_cross/rsi_oversold/rsi_overbought/breakout_20d/breakdown_20d/volume_surge/ma_golden_cross/ma_death_cross。要完整模拟交易过程用 run_backtest",
       parameters: Type.Object({
         symbol: Type.String({ description: "股票代码" }),
         signal: Type.Union(
@@ -556,7 +556,7 @@ export default definePluginEntry({
     api.registerTool({
       name: "get_volume_analysis",
       description:
-        "独立量价分析 — 量价相关性、上涨/下跌日成交量对比、量能趋势、量价模式解读（放量上涨/缩量回调等）。专问量能/量价配合时用本工具；综合技术面判断用 get_technical_analysis，扫当日异动用 detect_anomaly",
+        "独立量价分析 — 量价相关性、上涨/下跌日成交量对比、量能趋势、量价模式解读（放量上涨/缩量回调等）。综合技术面判断用 get_technical_analysis，扫当日异动用 detect_anomaly",
       parameters: Type.Object({
         symbol: Type.String({ description: "股票代码" }),
         period: Type.Optional(
@@ -608,7 +608,7 @@ export default definePluginEntry({
     api.registerTool({
       name: "search_comprehensive_intel",
       description:
-        "股票综合情报搜索 — 从6个维度（新闻/公告/行情分析/风险/业绩/行业）搜索综合信息。“深入研究/全面调研这家公司”用本工具；快速看新闻用 get_news",
+        "股票综合情报搜索 — 从6个维度（新闻/公告/行情分析/风险/业绩/行业）搜索综合信息。用于个股的深入研究/全面调研；快速看新闻用 get_news",
       parameters: Type.Object({
         symbol: Type.String({ description: "股票代码" }),
         name: Type.Optional(
@@ -626,7 +626,7 @@ export default definePluginEntry({
     api.registerTool({
       name: "get_social_sentiment",
       description:
-        "获取股票社交媒体情绪数据。A股：东方财富股吧热度+雪球讨论热度（无需配置）；美股/港股：Reddit/X/Polymarket情绪（需 SENTIMENT_API_KEY）。自动按市场选数据源。“散户在讨论什么/情绪如何”用本工具；看全市场热门讨论用 get_trending_sentiment",
+        "获取股票社交媒体情绪数据。A股：东方财富股吧热度+雪球讨论热度（无需配置）；美股/港股：Reddit/X/Polymarket情绪（需 SENTIMENT_API_KEY）。自动按市场选数据源。面向个股维度；全市场热门讨论用 get_trending_sentiment",
       parameters: Type.Object({
         symbol: Type.String({ description: "股票代码（如 AAPL）" }),
       }),
@@ -639,7 +639,7 @@ export default definePluginEntry({
     api.registerTool({
       name: "get_trending_sentiment",
       description:
-        "获取社交媒体热门趋势（Reddit/X/Polymarket热门股票讨论）。数据缓存10分钟。“现在市场热点是什么/大家都在买什么”用本工具；查个股情绪用 get_social_sentiment",
+        "获取社交媒体热门趋势（Reddit/X/Polymarket热门股票讨论）。数据缓存10分钟。适用于发现市场热点；查个股情绪用 get_social_sentiment",
       parameters: Type.Object({}),
       async execute() {
         const out = await runPy("search_intel.py", ["trending"]);
@@ -663,7 +663,7 @@ export default definePluginEntry({
     api.registerTool({
       name: "screen_risk",
       description:
-        "风险专项筛查 — 7维度风险检测（估值极端/技术预警/解禁到期/内部人减持/业绩预警/监管处罚/行业政策），返回风险评级和一票否决标记。“这股票有什么雷”用本工具；入场决策前排雷必调",
+        "风险专项筛查 — 7维度风险检测（估值极端/技术预警/解禁到期/内部人减持/业绩预警/监管处罚/行业政策），返回风险评级和一票否决标记。入场决策前的排雷必调本工具",
       parameters: Type.Object({
         symbol: Type.String({ description: "股票代码（如 600519）" }),
         name: Type.Optional(
@@ -681,7 +681,7 @@ export default definePluginEntry({
     api.registerTool({
       name: "detect_market_regime",
       description:
-        "市场状态检测 — 分析大盘指数判断当前市场阶段（上涨趋势/下跌趋势/横盘震荡/高波动/板块热点），并推荐适合的分析策略。“现在大盘能进场吗/该用什么策略”用本工具",
+        "市场状态检测 — 分析大盘指数判断当前市场阶段（上涨趋势/下跌趋势/横盘震荡/高波动/板块热点），并推荐适合的分析策略",
       parameters: Type.Object({
         market: Type.Optional(
           Type.Union(
@@ -702,7 +702,7 @@ export default definePluginEntry({
     api.registerTool({
       name: "get_market_review",
       description:
-        "大盘复盘 — 获取市场日度复盘数据，包含指数、涨跌统计、板块排名、新闻、市场温度与策略建议。“复盘一下今天市场/今天大盘怎么样”首选本工具，无需再分别调指数/统计/板块工具",
+        "大盘复盘 — 获取市场日度复盘数据，包含指数、涨跌统计、板块排名、新闻、市场温度与策略建议。复盘类需求的首选，无需再分别调指数/统计/板块工具",
       parameters: Type.Object({
         market: Type.Optional(
           Type.Union(
@@ -729,7 +729,7 @@ export default definePluginEntry({
     api.registerTool({
       name: "run_watchlist_analysis",
       description:
-        "批量自选股分析 — 对多只股票并行采集行情/技术/资金/风险等数据，返回汇总结果。“批量分析我的自选股”/每日定时分析用本工具",
+        "批量自选股分析 — 对多只股票并行采集行情/技术/资金/风险等数据，返回汇总结果。适用于每日定时分析自选股列表",
       parameters: Type.Object({
         symbols: Type.String({
           description: "逗号分隔的股票代码列表，如 600519,000001,300750",
@@ -754,7 +754,7 @@ export default definePluginEntry({
     api.registerTool({
       name: "detect_anomaly",
       description:
-        "异常/事件检测 — 一键扫描股票当前所有异动信号（MACD金叉死叉、RSI超买超卖、20日突破、放量异动、涨跌停、布林突破、KDJ极值、资金异动等），返回结构化异常列表。“今天有什么异动/为什么大涨大跌”首选本工具；综合技术面判断用 get_technical_analysis",
+        "异常/事件检测 — 一键扫描股票当前所有异动信号（MACD金叉死叉、RSI超买超卖、20日突破、放量异动、涨跌停、布林突破、KDJ极值、资金异动等），返回结构化异常列表。当日异动归因的首选；综合技术面判断用 get_technical_analysis",
       parameters: Type.Object({
         symbol: Type.String({
           description: "股票代码（如 600519、AAPL、00700.HK）",
@@ -901,7 +901,7 @@ export default definePluginEntry({
     api.registerTool({
       name: "analyze_position_context",
       description:
-        "持仓上下文分析 — 输入成本/仓位/止损止盈，结合现价和技术位输出浮盈亏、离止损距离、风险级别、操作建议。“我XX成本买的被套了/要不要止损止盈”用本工具。无状态、不存账户",
+        "持仓上下文分析 — 输入成本/仓位/止损止盈，结合现价和技术位输出浮盈亏、离止损距离、风险级别、操作建议。无状态、不存账户",
       parameters: Type.Object({
         symbol: Type.String({ description: "股票代码" }),
         cost: Type.Number({ description: "成本价" }),
@@ -932,7 +932,7 @@ export default definePluginEntry({
     api.registerTool({
       name: "check_alert_rules",
       description:
-        "无状态告警规则检查 — 传入规则数组，返回当前是否触发。规则类型：price_below/price_above/change_pct_above/change_pct_below/volume_ratio_above/anomaly/risk_veto/risk_level_at_least。“到价/涨跌幅提醒是否触发”用本工具。不做调度不存历史",
+        "无状态告警规则检查 — 传入规则数组，返回当前是否触发。规则类型：price_below/price_above/change_pct_above/change_pct_below/volume_ratio_above/anomaly/risk_veto/risk_level_at_least。不做调度不存历史",
       parameters: Type.Object({
         symbol: Type.String({ description: "股票代码" }),
         rules: Type.Array(

--- a/openclaw/index.ts
+++ b/openclaw/index.ts
@@ -60,7 +60,7 @@ export default definePluginEntry({
     api.registerTool({
       name: "get_kline",
       description:
-        "获取股票K线数据（OHLCV）。支持A股（如600519）、港股（如00700.HK）、美股（如AAPL）、日股（如7203.T）、韩股（如005930.KS）、台股（如2330.TW）及A股ETF",
+        "获取股票K线数据（OHLCV）。支持A股（如600519）、港股（如00700.HK）、美股（如AAPL）、日股（如7203.T）、韩股（如005930.KS）、台股（如2330.TW）及A股ETF。需要原始历史价格自行计算或画图时用；只问指标用 get_technical_analysis，只问现价用 get_quote",
       parameters: Type.Object({
         symbol: Type.String({
           description: "股票代码，如 600519（A股）、00700.HK（港股）、AAPL（美股）、7203.T（日股）、005930.KS（韩股）、2330.TW（台股）",
@@ -88,7 +88,7 @@ export default definePluginEntry({
 
     api.registerTool({
       name: "get_quote",
-      description: "获取股票实时行情报价。支持A股、港股、美股、日股、韩股、台股",
+      description: "获取股票实时行情报价（现价、涨跌幅、量比等）。支持A股、港股、美股、日股、韩股、台股。问“现在多少钱/涨了多少”用本工具",
       parameters: Type.Object({
         symbol: Type.String({ description: "股票代码" }),
       }),
@@ -101,7 +101,7 @@ export default definePluginEntry({
     api.registerTool({
       name: "get_capital_flow",
       description:
-        "获取A股资金流向数据。detail=个股每日明细，summary=多日汇总+趋势，sector_flow=板块资金流排行",
+        "获取A股资金流向（主力/超大单/大单/中单/小单净流入）。detail=个股每日明细，summary=多日汇总+趋势，sector_flow=板块资金流排行。问“主力在买还是卖/资金流入流出”用本工具，可配合 get_chip_distribution 验证",
       parameters: Type.Object({
         symbol: Type.Optional(
           Type.String({ description: "A股股票代码（detail/summary模式必填），如 600519" })
@@ -128,7 +128,7 @@ export default definePluginEntry({
 
     api.registerTool({
       name: "get_news",
-      description: "获取股票相关财经新闻",
+      description: "获取个股最近N天财经新闻快讯（轻量、无需配置）。需要深度全网情报用 search_comprehensive_intel，按主题搜索用 search_stock_news，读文章全文用 extract_article",
       parameters: Type.Object({
         symbol: Type.String({ description: "股票代码" }),
         days: Type.Optional(
@@ -148,7 +148,7 @@ export default definePluginEntry({
 
     api.registerTool({
       name: "get_financials",
-      description: "获取股票关键财务指标（PE/PB/市值/营收/净利润/ROE等）",
+      description: "获取股票关键财务指标（PE/PB/市值/营收/净利润/ROE等），适合快速估值快查。A股深度基本面（成长性/盈利能力/分红）用 get_fundamental_context",
       parameters: Type.Object({
         symbol: Type.String({ description: "股票代码" }),
       }),
@@ -163,7 +163,7 @@ export default definePluginEntry({
     api.registerTool({
       name: "get_technical_analysis",
       description:
-        "获取股票技术面分析（MA/MACD/RSI/BOLL/KDJ/成交量等指标 + 100分综合评分 + 6级买卖信号 + 趋势/偏离度/支撑压力位）",
+        "获取股票技术面分析（MA/MACD/RSI/BOLL/KDJ/成交量等指标 + 100分综合评分 + 6级买卖信号 + 趋势/偏离度/支撑压力位）。“能买吗/现在能入场吗/技术面怎么样”首选本工具；只要均线数值或自定义周期用 calculate_ma，专问量价用 get_volume_analysis，扫当日异动用 detect_anomaly",
       parameters: Type.Object({
         symbol: Type.String({ description: "股票代码" }),
         period: Type.Optional(
@@ -192,7 +192,7 @@ export default definePluginEntry({
     api.registerTool({
       name: "analyze_pattern",
       description:
-        "K线形态识别 — 检测十字星、锤子线、吞没、启明星、黄昏星、双底、20日突破等12+种经典形态",
+        "K线形态识别 — 检测十字星、锤子线、吞没、启明星、黄昏星、双底、20日突破等12+种经典形态。问“出现了什么形态”时用；综合技术面判断用 get_technical_analysis",
       parameters: Type.Object({
         symbol: Type.String({ description: "股票代码" }),
         period: Type.Optional(
@@ -223,7 +223,7 @@ export default definePluginEntry({
     api.registerTool({
       name: "get_market_indices",
       description:
-        "获取主要市场指数行情。CN: 上证/深证/创业板/科创50/沪深300；HK: 恒生/国企/科技；US: 道琼斯/纳斯达克/标普500；JP: 日经225/东证；KR: KOSPI/KOSDAQ；TW: 台湾加权",
+        "获取主要市场指数行情。CN: 上证/深证/创业板/科创50/沪深300；HK: 恒生/国企/科技；US: 道琼斯/纳斯达克/标普500；JP: 日经225/东证；KR: KOSPI/KOSDAQ；TW: 台湾加权。“复盘今天大盘”用 get_market_review 一站式获取",
       parameters: Type.Object({
         region: Type.Optional(
           Type.Union(
@@ -245,7 +245,7 @@ export default definePluginEntry({
     api.registerTool({
       name: "get_sector_rankings",
       description:
-        "获取A股行业板块涨跌幅排行（含领涨股、涨跌家数等）。支持查看涨幅榜/跌幅榜/双向",
+        "获取A股行业板块涨跌幅排行（含领涨股、涨跌家数等）。支持查看涨幅榜/跌幅榜/双向。找热点板块/领涨板块用本工具",
       parameters: Type.Object({
         top: Type.Optional(
           Type.Number({ description: "返回排名前N的板块，默认 10" })
@@ -285,7 +285,7 @@ export default definePluginEntry({
     api.registerTool({
       name: "get_chip_distribution",
       description:
-        "获取A股筹码分布数据（获利比例、平均成本、90%/70%成本集中度）。仅支持A股",
+        "获取A股筹码分布数据（获利比例、平均成本、90%/70%成本集中度）。仅支持A股。与 get_capital_flow 配合验证主力行为",
       parameters: Type.Object({
         symbol: Type.String({ description: "A股股票代码，如 600519" }),
       }),
@@ -301,7 +301,7 @@ export default definePluginEntry({
     api.registerTool({
       name: "get_market_stats",
       description:
-        "获取A股市场整体统计（涨跌家数、涨停跌停数、平均涨幅、涨跌Top5、总成交额）",
+        "获取A股市场整体统计（涨跌家数、涨停跌停数、平均涨幅、涨跌Top5、总成交额）。问“今天市场情绪/温度如何”用本工具",
       parameters: Type.Object({
         market: Type.Optional(
           Type.Union([Type.Literal("A")], { description: "市场，目前仅支持 A" })
@@ -320,7 +320,7 @@ export default definePluginEntry({
     api.registerTool({
       name: "get_fundamental_context",
       description:
-        "获取A股深度基本面（估值PE/PB/PS + 成长性营收/净利增速 + 盈利能力ROE/毛利率 + 分红历史）",
+        "获取A股深度基本面（估值PE/PB/PS + 成长性营收/净利增速 + 盈利能力ROE/毛利率 + 分红历史）。“公司质地如何/能不能长期持有”用本工具；快速查PE/PB用 get_financials",
       parameters: Type.Object({
         symbol: Type.String({ description: "A股股票代码，如 600519" }),
       }),
@@ -338,7 +338,7 @@ export default definePluginEntry({
     api.registerTool({
       name: "screen_stocks",
       description:
-        "全市场股票筛选（AlphaSift L1 多因子硬筛）。按PE/PB/市值/换手率/涨跌幅/量比等因子过滤和评分",
+        "全市场股票筛选（AlphaSift L1 多因子硬筛）。按PE/PB/市值/换手率/涨跌幅/量比等因子过滤和评分。“帮我选股/筛选低估值/高换手股票”用本工具",
       parameters: Type.Object({
         market: Type.Optional(
           Type.Union(
@@ -370,7 +370,7 @@ export default definePluginEntry({
     api.registerTool({
       name: "run_backtest",
       description:
-        "策略回测（AlphaEvo）。读取YAML策略定义，在历史数据上模拟交易，输出收益率/回撤/胜率等指标",
+        "策略回测（AlphaEvo）。读取YAML策略定义，在历史数据上模拟交易，输出收益率/回撤/胜率等指标。只想知道单个技术信号的历史胜率用更轻量的 evaluate_signal",
       parameters: Type.Object({
         strategy: Type.String({ description: "策略YAML文件路径" }),
         symbol: Type.String({ description: "股票代码" }),
@@ -397,7 +397,7 @@ export default definePluginEntry({
     api.registerTool({
       name: "evaluate_signal",
       description:
-        "技术信号历史准确率评估 — 回溯历史数据，统计某个技术信号触发后N日的胜率和平均收益。支持9种信号：macd_golden_cross/macd_death_cross/rsi_oversold/rsi_overbought/breakout_20d/breakdown_20d/volume_surge/ma_golden_cross/ma_death_cross",
+        "技术信号历史准确率评估 — 回溯历史数据，统计某个技术信号触发后N日的胜率和平均收益。支持9种信号：macd_golden_cross/macd_death_cross/rsi_oversold/rsi_overbought/breakout_20d/breakdown_20d/volume_surge/ma_golden_cross/ma_death_cross。“金叉/突破策略靠不靠谱”用本工具；要完整模拟交易过程用 run_backtest",
       parameters: Type.Object({
         symbol: Type.String({ description: "股票代码" }),
         signal: Type.Union(
@@ -440,7 +440,7 @@ export default definePluginEntry({
     api.registerTool({
       name: "resolve_stock_name",
       description:
-        "股票名称智能解析 — 输入中文名（贵州茅台）、拼音（guizhou maotai/gzmt）、部分代码，返回匹配的股票代码。仅支持A股",
+        "股票名称智能解析 — 输入中文名（贵州茅台）、拼音（guizhou maotai/gzmt）、部分代码，返回匹配的股票代码。仅支持A股。用户给出中文名/拼音/部分代码时先调本工具换成代码再调其他工具",
       parameters: Type.Object({
         query: Type.String({
           description: "股票名称、拼音、拼音首字母或部分代码",
@@ -521,7 +521,7 @@ export default definePluginEntry({
     api.registerTool({
       name: "calculate_ma",
       description:
-        "独立均线计算器 — 支持任意周期MA（5/10/20/30/60/120/250或自定义）+ 偏离度 + 均线排列 + 金叉死叉检测",
+        "独立均线计算器 — 支持任意周期MA（5/10/20/30/60/120/250或自定义）+ 偏离度 + 均线排列 + 金叉死叉检测。只要均线数值或需要30/120/250等非默认周期时用本工具；综合技术面分析用 get_technical_analysis",
       parameters: Type.Object({
         symbol: Type.String({ description: "股票代码" }),
         periods: Type.Optional(
@@ -556,7 +556,7 @@ export default definePluginEntry({
     api.registerTool({
       name: "get_volume_analysis",
       description:
-        "独立量价分析 — 量价相关性、上涨/下跌日成交量对比、量能趋势、量价模式解读（放量上涨/缩量回调等）",
+        "独立量价分析 — 量价相关性、上涨/下跌日成交量对比、量能趋势、量价模式解读（放量上涨/缩量回调等）。专问量能/量价配合时用本工具；综合技术面判断用 get_technical_analysis，扫当日异动用 detect_anomaly",
       parameters: Type.Object({
         symbol: Type.String({ description: "股票代码" }),
         period: Type.Optional(
@@ -587,7 +587,7 @@ export default definePluginEntry({
     api.registerTool({
       name: "search_stock_news",
       description:
-        "多引擎股票新闻搜索（支持 Tavily/Brave/SerpAPI）。需配置对应 API Key 环境变量",
+        "多引擎股票新闻搜索（支持 Tavily/Brave/SerpAPI）。需配置对应 API Key 环境变量。get_news 快讯不够或要按主题搜索时用本工具；深度6维情报用 search_comprehensive_intel",
       parameters: Type.Object({
         query: Type.String({ description: "搜索关键词" }),
         count: Type.Optional(
@@ -608,7 +608,7 @@ export default definePluginEntry({
     api.registerTool({
       name: "search_comprehensive_intel",
       description:
-        "股票综合情报搜索 — 从6个维度（新闻/公告/行情分析/风险/业绩/行业）搜索综合信息",
+        "股票综合情报搜索 — 从6个维度（新闻/公告/行情分析/风险/业绩/行业）搜索综合信息。“深入研究/全面调研这家公司”用本工具；快速看新闻用 get_news",
       parameters: Type.Object({
         symbol: Type.String({ description: "股票代码" }),
         name: Type.Optional(
@@ -626,7 +626,7 @@ export default definePluginEntry({
     api.registerTool({
       name: "get_social_sentiment",
       description:
-        "获取股票社交媒体情绪数据（Reddit/X/Polymarket）。主要支持美股。需配置 SENTIMENT_API_KEY",
+        "获取股票社交媒体情绪数据。A股：东方财富股吧热度+雪球讨论热度（无需配置）；美股/港股：Reddit/X/Polymarket情绪（需 SENTIMENT_API_KEY）。自动按市场选数据源。“散户在讨论什么/情绪如何”用本工具；看全市场热门讨论用 get_trending_sentiment",
       parameters: Type.Object({
         symbol: Type.String({ description: "股票代码（如 AAPL）" }),
       }),
@@ -639,7 +639,7 @@ export default definePluginEntry({
     api.registerTool({
       name: "get_trending_sentiment",
       description:
-        "获取社交媒体热门趋势（Reddit/X/Polymarket热门股票讨论）。数据缓存10分钟。适用于发现市场热点",
+        "获取社交媒体热门趋势（Reddit/X/Polymarket热门股票讨论）。数据缓存10分钟。“现在市场热点是什么/大家都在买什么”用本工具；查个股情绪用 get_social_sentiment",
       parameters: Type.Object({}),
       async execute() {
         const out = await runPy("search_intel.py", ["trending"]);
@@ -650,7 +650,7 @@ export default definePluginEntry({
     api.registerTool({
       name: "extract_article",
       description:
-        "网页文章全文提取 — 输入URL，提取文章标题、正文（最多3000字）、作者、发布日期等。适用于深度阅读搜索结果中的新闻/研报",
+        "网页文章全文提取 — 输入URL，提取文章标题、正文（最多3000字）、作者、发布日期等。配合 get_news/search_stock_news 的搜索结果做深度阅读",
       parameters: Type.Object({
         url: Type.String({ description: "文章URL" }),
       }),
@@ -663,7 +663,7 @@ export default definePluginEntry({
     api.registerTool({
       name: "screen_risk",
       description:
-        "风险专项筛查 — 7维度风险检测（估值极端/技术预警/解禁到期/内部人减持/业绩预警/监管处罚/行业政策），返回风险评级和一票否决标记",
+        "风险专项筛查 — 7维度风险检测（估值极端/技术预警/解禁到期/内部人减持/业绩预警/监管处罚/行业政策），返回风险评级和一票否决标记。“这股票有什么雷”用本工具；入场决策前排雷必调",
       parameters: Type.Object({
         symbol: Type.String({ description: "股票代码（如 600519）" }),
         name: Type.Optional(
@@ -681,7 +681,7 @@ export default definePluginEntry({
     api.registerTool({
       name: "detect_market_regime",
       description:
-        "市场状态检测 — 分析大盘指数判断当前市场阶段（上涨趋势/下跌趋势/横盘震荡/高波动/板块热点），并推荐适合的分析策略",
+        "市场状态检测 — 分析大盘指数判断当前市场阶段（上涨趋势/下跌趋势/横盘震荡/高波动/板块热点），并推荐适合的分析策略。“现在大盘能进场吗/该用什么策略”用本工具",
       parameters: Type.Object({
         market: Type.Optional(
           Type.Union(
@@ -702,7 +702,7 @@ export default definePluginEntry({
     api.registerTool({
       name: "get_market_review",
       description:
-        "大盘复盘 — 获取市场日度复盘数据，包含指数、涨跌统计、板块排名、新闻、市场温度与策略建议",
+        "大盘复盘 — 获取市场日度复盘数据，包含指数、涨跌统计、板块排名、新闻、市场温度与策略建议。“复盘一下今天市场/今天大盘怎么样”首选本工具，无需再分别调指数/统计/板块工具",
       parameters: Type.Object({
         market: Type.Optional(
           Type.Union(
@@ -729,7 +729,7 @@ export default definePluginEntry({
     api.registerTool({
       name: "run_watchlist_analysis",
       description:
-        "批量自选股分析 — 对多只股票并行采集行情/技术/资金/风险等数据，返回汇总结果。适用于每日定时分析自选股列表",
+        "批量自选股分析 — 对多只股票并行采集行情/技术/资金/风险等数据，返回汇总结果。“批量分析我的自选股”/每日定时分析用本工具",
       parameters: Type.Object({
         symbols: Type.String({
           description: "逗号分隔的股票代码列表，如 600519,000001,300750",
@@ -754,7 +754,7 @@ export default definePluginEntry({
     api.registerTool({
       name: "detect_anomaly",
       description:
-        "异常/事件检测 — 一键扫描股票当前所有异动信号（MACD金叉死叉、RSI超买超卖、20日突破、放量异动、涨跌停、布林突破、KDJ极值、资金异动等），返回结构化异常列表",
+        "异常/事件检测 — 一键扫描股票当前所有异动信号（MACD金叉死叉、RSI超买超卖、20日突破、放量异动、涨跌停、布林突破、KDJ极值、资金异动等），返回结构化异常列表。“今天有什么异动/为什么大涨大跌”首选本工具；综合技术面判断用 get_technical_analysis",
       parameters: Type.Object({
         symbol: Type.String({
           description: "股票代码（如 600519、AAPL、00700.HK）",
@@ -771,7 +771,7 @@ export default definePluginEntry({
     api.registerTool({
       name: "diagnose_data_sources",
       description:
-        "数据源诊断 — 检查当前环境可用的数据 provider（akshare/tushare/yfinance/finnhub/longbridge/alphavantage），输出每个市场的可用链路、缺失 env、warnings",
+        "数据源诊断 — 检查当前环境可用的数据 provider（akshare/tushare/yfinance/finnhub/longbridge/alphavantage），输出每个市场的可用链路、缺失 env、warnings。工具拿不到数据或报错时调用排查",
       parameters: Type.Object({
         market: Type.Optional(
           Type.Union(
@@ -801,7 +801,7 @@ export default definePluginEntry({
     api.registerTool({
       name: "get_market_capabilities",
       description:
-        "市场能力边界 — 返回指定市场支持/不支持的工具列表，避免 agent 对港股调 get_chip_distribution 或对美股调 get_capital_flow 后编造数据",
+        "市场能力边界 — 返回指定市场支持/不支持的工具列表。不确定某市场能否用某工具（如港股的筹码分布、美股的资金流）时先调本工具，避免调用不支持的工具后编造数据",
       parameters: Type.Object({
         market: Type.Optional(
           Type.Union(
@@ -827,7 +827,7 @@ export default definePluginEntry({
     api.registerTool({
       name: "render_stock_report",
       description:
-        "股票分析报告渲染 — 将结构化 JSON（符合 schemas/report_schema.json）通过 j2 模板渲染为 Markdown。template: brief|full。仅渲染，不保存不推送",
+        "股票分析报告渲染 — 将结构化 JSON（符合 schemas/report_schema.json）通过 j2 模板渲染为 Markdown。template: brief|full。全部分析完成后的最后一步调用。仅渲染，不保存不推送",
       parameters: Type.Object({
         report: Type.Object({}, { additionalProperties: true, description: "结构化股票报告" }),
         template: Type.Optional(
@@ -901,7 +901,7 @@ export default definePluginEntry({
     api.registerTool({
       name: "analyze_position_context",
       description:
-        "持仓上下文分析 — 输入成本/仓位/止损止盈，结合现价和技术位输出浮盈亏、离止损距离、风险级别、操作建议。无状态、不存账户",
+        "持仓上下文分析 — 输入成本/仓位/止损止盈，结合现价和技术位输出浮盈亏、离止损距离、风险级别、操作建议。“我XX成本买的被套了/要不要止损止盈”用本工具。无状态、不存账户",
       parameters: Type.Object({
         symbol: Type.String({ description: "股票代码" }),
         cost: Type.Number({ description: "成本价" }),
@@ -932,7 +932,7 @@ export default definePluginEntry({
     api.registerTool({
       name: "check_alert_rules",
       description:
-        "无状态告警规则检查 — 传入规则数组，返回当前是否触发。规则类型：price_below/price_above/change_pct_above/change_pct_below/volume_ratio_above/anomaly/risk_veto/risk_level_at_least。不做调度不存历史",
+        "无状态告警规则检查 — 传入规则数组，返回当前是否触发。规则类型：price_below/price_above/change_pct_above/change_pct_below/volume_ratio_above/anomaly/risk_veto/risk_level_at_least。“到价/涨跌幅提醒是否触发”用本工具。不做调度不存历史",
       parameters: Type.Object({
         symbol: Type.String({ description: "股票代码" }),
         rules: Type.Array(

--- a/pi/index.ts
+++ b/pi/index.ts
@@ -63,7 +63,7 @@ export default (pi: ExtensionAPI) => {
   pi.registerTool({
     name: "get_quote",
     description:
-      "获取股票实时行情报价（现价、涨跌幅、量比等）。支持A股、港股、美股、日股、韩股、台股。问“现在多少钱/涨了多少”用本工具",
+      "获取股票实时行情报价（现价、涨跌幅、量比等）。支持A股、港股、美股、日股、韩股、台股",
     parameters: {
       type: "object",
       properties: {
@@ -83,7 +83,7 @@ export default (pi: ExtensionAPI) => {
   pi.registerTool({
     name: "get_capital_flow",
     description:
-      "获取A股资金流向（主力/超大单/大单/中单/小单净流入）。detail=个股每日明细，summary=多日汇总+趋势，sector_flow=板块资金流排行。问“主力在买还是卖/资金流入流出”用本工具，可配合 get_chip_distribution 验证",
+      "获取A股资金流向（主力/超大单/大单/中单/小单净流入）。detail=个股每日明细，summary=多日汇总+趋势，sector_flow=板块资金流排行。可配合 get_chip_distribution 验证主力行为",
     parameters: {
       type: "object",
       properties: {
@@ -157,7 +157,7 @@ export default (pi: ExtensionAPI) => {
   pi.registerTool({
     name: "get_technical_analysis",
     description:
-      "获取股票技术面分析（MA/MACD/RSI/BOLL/KDJ/成交量等指标 + 100分综合评分 + 6级买卖信号 + 趋势/偏离度/支撑压力位）。“能买吗/现在能入场吗/技术面怎么样”首选本工具；只要均线数值或自定义周期用 calculate_ma，专问量价用 get_volume_analysis，扫当日异动用 detect_anomaly",
+      "获取股票技术面分析（MA/MACD/RSI/BOLL/KDJ/成交量等指标 + 100分综合评分 + 6级买卖信号 + 趋势/偏离度/支撑压力位）。个股技术面综合判断与买卖时机分析的首选；只要均线数值或自定义周期用 calculate_ma，专问量价用 get_volume_analysis，扫当日异动用 detect_anomaly",
     parameters: {
       type: "object",
       properties: {
@@ -193,7 +193,7 @@ export default (pi: ExtensionAPI) => {
   pi.registerTool({
     name: "analyze_pattern",
     description:
-      "K线形态识别 — 检测十字星、锤子线、吞没、启明星、黄昏星、双底、20日突破等12+种经典形态。问“出现了什么形态”时用；综合技术面判断用 get_technical_analysis",
+      "K线形态识别 — 检测十字星、锤子线、吞没、启明星、黄昏星、双底、20日突破等12+种经典形态。综合技术面判断用 get_technical_analysis",
     parameters: {
       type: "object",
       properties: {
@@ -231,7 +231,7 @@ export default (pi: ExtensionAPI) => {
   pi.registerTool({
     name: "get_market_indices",
     description:
-      "获取主要市场指数行情。CN: 上证/深证/创业板/科创50/沪深300；HK: 恒生/国企/科技；US: 道琼斯/纳斯达克/标普500；JP: 日经225/东证；KR: KOSPI/KOSDAQ；TW: 台湾加权。“复盘今天大盘”用 get_market_review 一站式获取",
+      "获取主要市场指数行情。CN: 上证/深证/创业板/科创50/沪深300；HK: 恒生/国企/科技；US: 道琼斯/纳斯达克/标普500；JP: 日经225/东证；KR: KOSPI/KOSDAQ；TW: 台湾加权。大盘复盘用 get_market_review 一站式获取",
     parameters: {
       type: "object",
       properties: {
@@ -254,7 +254,7 @@ export default (pi: ExtensionAPI) => {
 
   pi.registerTool({
     name: "get_sector_rankings",
-    description: "获取A股行业板块涨跌幅排行（含领涨股、涨跌家数等）。支持查看涨幅榜/跌幅榜/双向。找热点板块/领涨板块用本工具",
+    description: "获取A股行业板块涨跌幅排行（含领涨股、涨跌家数等）。支持查看涨幅榜/跌幅榜/双向",
     parameters: {
       type: "object",
       properties: {
@@ -324,7 +324,7 @@ export default (pi: ExtensionAPI) => {
   pi.registerTool({
     name: "get_market_stats",
     description:
-      "获取A股市场整体统计（涨跌家数、涨停跌停数、平均涨幅、涨跌Top5、总成交额）。问“今天市场情绪/温度如何”用本工具",
+      "获取A股市场整体统计（涨跌家数、涨停跌停数、平均涨幅、涨跌Top5、总成交额）。用于衡量市场整体情绪与温度",
     parameters: {
       type: "object",
       properties: {
@@ -344,7 +344,7 @@ export default (pi: ExtensionAPI) => {
   pi.registerTool({
     name: "get_fundamental_context",
     description:
-      "获取A股深度基本面（估值PE/PB/PS + 成长性营收/净利增速 + 盈利能力ROE/毛利率 + 分红历史）。“公司质地如何/能不能长期持有”用本工具；快速查PE/PB用 get_financials",
+      "获取A股深度基本面（估值PE/PB/PS + 成长性营收/净利增速 + 盈利能力ROE/毛利率 + 分红历史）。用于评估公司质地与长期持有价值；快速查PE/PB用 get_financials",
     parameters: {
       type: "object",
       properties: {
@@ -366,7 +366,7 @@ export default (pi: ExtensionAPI) => {
   pi.registerTool({
     name: "screen_stocks",
     description:
-      "全市场股票筛选（AlphaSift L1 多因子硬筛）。按PE/PB/市值/换手率/涨跌幅/量比等因子过滤和评分。“帮我选股/筛选低估值/高换手股票”用本工具",
+      "全市场股票筛选（AlphaSift L1 多因子硬筛）。按PE/PB/市值/换手率/涨跌幅/量比等因子过滤和评分",
     parameters: {
       type: "object",
       properties: {
@@ -445,7 +445,7 @@ export default (pi: ExtensionAPI) => {
   pi.registerTool({
     name: "evaluate_signal",
     description:
-      "技术信号历史准确率评估 — 回溯历史数据，统计某个技术信号触发后N日的胜率和平均收益。支持9种信号：macd_golden_cross/macd_death_cross/rsi_oversold/rsi_overbought/breakout_20d/breakdown_20d/volume_surge/ma_golden_cross/ma_death_cross。“金叉/突破策略靠不靠谱”用本工具；要完整模拟交易过程用 run_backtest",
+      "技术信号历史准确率评估 — 回溯历史数据，统计某个技术信号触发后N日的胜率和平均收益。支持9种信号：macd_golden_cross/macd_death_cross/rsi_oversold/rsi_overbought/breakout_20d/breakdown_20d/volume_surge/ma_golden_cross/ma_death_cross。要完整模拟交易过程用 run_backtest",
     parameters: {
       type: "object",
       properties: {
@@ -640,7 +640,7 @@ export default (pi: ExtensionAPI) => {
   pi.registerTool({
     name: "get_volume_analysis",
     description:
-      "独立量价分析 — 量价相关性、上涨/下跌日成交量对比、量能趋势、量价模式解读（放量上涨/缩量回调等）。专问量能/量价配合时用本工具；综合技术面判断用 get_technical_analysis，扫当日异动用 detect_anomaly",
+      "独立量价分析 — 量价相关性、上涨/下跌日成交量对比、量能趋势、量价模式解读（放量上涨/缩量回调等）。综合技术面判断用 get_technical_analysis，扫当日异动用 detect_anomaly",
     parameters: {
       type: "object",
       properties: {
@@ -707,7 +707,7 @@ export default (pi: ExtensionAPI) => {
   pi.registerTool({
     name: "search_comprehensive_intel",
     description:
-      "股票综合情报搜索 — 从6个维度（新闻/公告/行情分析/风险/业绩/行业）搜索综合信息。“深入研究/全面调研这家公司”用本工具；快速看新闻用 get_news",
+      "股票综合情报搜索 — 从6个维度（新闻/公告/行情分析/风险/业绩/行业）搜索综合信息。用于个股的深入研究/全面调研；快速看新闻用 get_news",
     parameters: {
       type: "object",
       properties: {
@@ -735,7 +735,7 @@ export default (pi: ExtensionAPI) => {
   pi.registerTool({
     name: "get_social_sentiment",
     description:
-      "获取股票社交媒体情绪数据。A股：东方财富股吧热度+雪球讨论热度（无需配置）；美股/港股：Reddit/X/Polymarket情绪（需 SENTIMENT_API_KEY）。自动按市场选数据源。“散户在讨论什么/情绪如何”用本工具；看全市场热门讨论用 get_trending_sentiment",
+      "获取股票社交媒体情绪数据。A股：东方财富股吧热度+雪球讨论热度（无需配置）；美股/港股：Reddit/X/Polymarket情绪（需 SENTIMENT_API_KEY）。自动按市场选数据源。面向个股维度；全市场热门讨论用 get_trending_sentiment",
     parameters: {
       type: "object",
       properties: {
@@ -755,7 +755,7 @@ export default (pi: ExtensionAPI) => {
   pi.registerTool({
     name: "get_trending_sentiment",
     description:
-      "获取社交媒体热门趋势（Reddit/X/Polymarket热门股票讨论）。数据缓存10分钟。“现在市场热点是什么/大家都在买什么”用本工具；查个股情绪用 get_social_sentiment",
+      "获取社交媒体热门趋势（Reddit/X/Polymarket热门股票讨论）。数据缓存10分钟。适用于发现市场热点；查个股情绪用 get_social_sentiment",
     parameters: {
       type: "object",
       properties: {},
@@ -789,7 +789,7 @@ export default (pi: ExtensionAPI) => {
   pi.registerTool({
     name: "screen_risk",
     description:
-      "风险专项筛查 — 7维度风险检测（估值极端/技术预警/解禁到期/内部人减持/业绩预警/监管处罚/行业政策），返回风险评级和一票否决标记。“这股票有什么雷”用本工具；入场决策前排雷必调",
+      "风险专项筛查 — 7维度风险检测（估值极端/技术预警/解禁到期/内部人减持/业绩预警/监管处罚/行业政策），返回风险评级和一票否决标记。入场决策前的排雷必调本工具",
     parameters: {
       type: "object",
       properties: {
@@ -817,7 +817,7 @@ export default (pi: ExtensionAPI) => {
   pi.registerTool({
     name: "detect_market_regime",
     description:
-      "市场状态检测 — 分析大盘指数判断当前市场阶段（上涨趋势/下跌趋势/横盘震荡/高波动/板块热点），并推荐适合的分析策略。“现在大盘能进场吗/该用什么策略”用本工具",
+      "市场状态检测 — 分析大盘指数判断当前市场阶段（上涨趋势/下跌趋势/横盘震荡/高波动/板块热点），并推荐适合的分析策略",
     parameters: {
       type: "object",
       properties: {
@@ -838,7 +838,7 @@ export default (pi: ExtensionAPI) => {
   pi.registerTool({
     name: "get_market_review",
     description:
-      "大盘复盘 — 获取市场日度复盘数据，包含指数、涨跌统计、板块排名、新闻、市场温度与策略建议。“复盘一下今天市场/今天大盘怎么样”首选本工具，无需再分别调指数/统计/板块工具",
+      "大盘复盘 — 获取市场日度复盘数据，包含指数、涨跌统计、板块排名、新闻、市场温度与策略建议。复盘类需求的首选，无需再分别调指数/统计/板块工具",
     parameters: {
       type: "object",
       properties: {
@@ -859,7 +859,7 @@ export default (pi: ExtensionAPI) => {
   pi.registerTool({
     name: "run_watchlist_analysis",
     description:
-      "批量自选股分析 — 对多只股票并行采集行情/技术/资金/风险等数据，返回汇总结果。“批量分析我的自选股”/每日定时分析用本工具",
+      "批量自选股分析 — 对多只股票并行采集行情/技术/资金/风险等数据，返回汇总结果。适用于每日定时分析自选股列表",
     parameters: {
       type: "object",
       properties: {
@@ -888,7 +888,7 @@ export default (pi: ExtensionAPI) => {
   pi.registerTool({
     name: "detect_anomaly",
     description:
-      "异常/事件检测 — 一键扫描股票当前所有异动信号（MACD金叉死叉、RSI超买超卖、20日突破、放量异动、涨跌停、布林突破、KDJ极值、资金异动等），返回结构化异常列表。“今天有什么异动/为什么大涨大跌”首选本工具；综合技术面判断用 get_technical_analysis",
+      "异常/事件检测 — 一键扫描股票当前所有异动信号（MACD金叉死叉、RSI超买超卖、20日突破、放量异动、涨跌停、布林突破、KDJ极值、资金异动等），返回结构化异常列表。当日异动归因的首选；综合技术面判断用 get_technical_analysis",
     parameters: {
       type: "object",
       properties: {
@@ -1039,7 +1039,7 @@ export default (pi: ExtensionAPI) => {
   pi.registerTool({
     name: "analyze_position_context",
     description:
-      "持仓上下文分析 — 输入成本/仓位/止损止盈，结合现价和技术位输出浮盈亏、离止损距离、风险级别、操作建议。“我XX成本买的被套了/要不要止损止盈”用本工具。无状态、不存账户",
+      "持仓上下文分析 — 输入成本/仓位/止损止盈，结合现价和技术位输出浮盈亏、离止损距离、风险级别、操作建议。无状态、不存账户",
     parameters: {
       type: "object",
       properties: {
@@ -1069,7 +1069,7 @@ export default (pi: ExtensionAPI) => {
   pi.registerTool({
     name: "check_alert_rules",
     description:
-      "无状态告警规则检查 — 传入规则数组，返回当前是否触发。规则类型：price_below/price_above/change_pct_above/change_pct_below/volume_ratio_above/anomaly/risk_veto/risk_level_at_least。“到价/涨跌幅提醒是否触发”用本工具。不做调度不存历史",
+      "无状态告警规则检查 — 传入规则数组，返回当前是否触发。规则类型：price_below/price_above/change_pct_above/change_pct_below/volume_ratio_above/anomaly/risk_veto/risk_level_at_least。不做调度不存历史",
     parameters: {
       type: "object",
       properties: {

--- a/pi/index.ts
+++ b/pi/index.ts
@@ -27,7 +27,7 @@ export default (pi: ExtensionAPI) => {
   pi.registerTool({
     name: "get_kline",
     description:
-      "获取股票K线数据（OHLCV）。支持A股（如600519）、港股（如00700.HK）、美股（如AAPL）、日股（如7203.T）、韩股（如005930.KS）、台股（如2330.TW）及A股ETF",
+      "获取股票K线数据（OHLCV）。支持A股（如600519）、港股（如00700.HK）、美股（如AAPL）、日股（如7203.T）、韩股（如005930.KS）、台股（如2330.TW）及A股ETF。需要原始历史价格自行计算或画图时用；只问指标用 get_technical_analysis，只问现价用 get_quote",
     parameters: {
       type: "object",
       properties: {
@@ -63,7 +63,7 @@ export default (pi: ExtensionAPI) => {
   pi.registerTool({
     name: "get_quote",
     description:
-      "获取股票实时行情报价。支持A股、港股、美股、日股、韩股、台股",
+      "获取股票实时行情报价（现价、涨跌幅、量比等）。支持A股、港股、美股、日股、韩股、台股。问“现在多少钱/涨了多少”用本工具",
     parameters: {
       type: "object",
       properties: {
@@ -83,7 +83,7 @@ export default (pi: ExtensionAPI) => {
   pi.registerTool({
     name: "get_capital_flow",
     description:
-      "获取A股资金流向数据。detail=个股每日明细，summary=多日汇总+趋势，sector_flow=板块资金流排行",
+      "获取A股资金流向（主力/超大单/大单/中单/小单净流入）。detail=个股每日明细，summary=多日汇总+趋势，sector_flow=板块资金流排行。问“主力在买还是卖/资金流入流出”用本工具，可配合 get_chip_distribution 验证",
     parameters: {
       type: "object",
       properties: {
@@ -111,7 +111,7 @@ export default (pi: ExtensionAPI) => {
 
   pi.registerTool({
     name: "get_news",
-    description: "获取股票相关财经新闻",
+    description: "获取个股最近N天财经新闻快讯（轻量、无需配置）。需要深度全网情报用 search_comprehensive_intel，按主题搜索用 search_stock_news，读文章全文用 extract_article",
     parameters: {
       type: "object",
       properties: {
@@ -135,7 +135,7 @@ export default (pi: ExtensionAPI) => {
   pi.registerTool({
     name: "get_financials",
     description:
-      "获取股票关键财务指标（PE/PB/市值/营收/净利润/ROE等）",
+      "获取股票关键财务指标（PE/PB/市值/营收/净利润/ROE等），适合快速估值快查。A股深度基本面（成长性/盈利能力/分红）用 get_fundamental_context",
     parameters: {
       type: "object",
       properties: {
@@ -157,7 +157,7 @@ export default (pi: ExtensionAPI) => {
   pi.registerTool({
     name: "get_technical_analysis",
     description:
-      "获取股票技术面分析（MA/MACD/RSI/BOLL/KDJ/成交量等指标 + 100分综合评分 + 6级买卖信号 + 趋势/偏离度/支撑压力位）",
+      "获取股票技术面分析（MA/MACD/RSI/BOLL/KDJ/成交量等指标 + 100分综合评分 + 6级买卖信号 + 趋势/偏离度/支撑压力位）。“能买吗/现在能入场吗/技术面怎么样”首选本工具；只要均线数值或自定义周期用 calculate_ma，专问量价用 get_volume_analysis，扫当日异动用 detect_anomaly",
     parameters: {
       type: "object",
       properties: {
@@ -193,7 +193,7 @@ export default (pi: ExtensionAPI) => {
   pi.registerTool({
     name: "analyze_pattern",
     description:
-      "K线形态识别 — 检测十字星、锤子线、吞没、启明星、黄昏星、双底、20日突破等12+种经典形态",
+      "K线形态识别 — 检测十字星、锤子线、吞没、启明星、黄昏星、双底、20日突破等12+种经典形态。问“出现了什么形态”时用；综合技术面判断用 get_technical_analysis",
     parameters: {
       type: "object",
       properties: {
@@ -231,7 +231,7 @@ export default (pi: ExtensionAPI) => {
   pi.registerTool({
     name: "get_market_indices",
     description:
-      "获取主要市场指数行情。CN: 上证/深证/创业板/科创50/沪深300；HK: 恒生/国企/科技；US: 道琼斯/纳斯达克/标普500；JP: 日经225/东证；KR: KOSPI/KOSDAQ；TW: 台湾加权",
+      "获取主要市场指数行情。CN: 上证/深证/创业板/科创50/沪深300；HK: 恒生/国企/科技；US: 道琼斯/纳斯达克/标普500；JP: 日经225/东证；KR: KOSPI/KOSDAQ；TW: 台湾加权。“复盘今天大盘”用 get_market_review 一站式获取",
     parameters: {
       type: "object",
       properties: {
@@ -254,7 +254,7 @@ export default (pi: ExtensionAPI) => {
 
   pi.registerTool({
     name: "get_sector_rankings",
-    description: "获取A股行业板块涨跌幅排行（含领涨股、涨跌家数等）。支持查看涨幅榜/跌幅榜/双向",
+    description: "获取A股行业板块涨跌幅排行（含领涨股、涨跌家数等）。支持查看涨幅榜/跌幅榜/双向。找热点板块/领涨板块用本工具",
     parameters: {
       type: "object",
       properties: {
@@ -304,7 +304,7 @@ export default (pi: ExtensionAPI) => {
   pi.registerTool({
     name: "get_chip_distribution",
     description:
-      "获取A股筹码分布数据（获利比例、平均成本、90%/70%成本集中度）。仅支持A股",
+      "获取A股筹码分布数据（获利比例、平均成本、90%/70%成本集中度）。仅支持A股。与 get_capital_flow 配合验证主力行为",
     parameters: {
       type: "object",
       properties: {
@@ -324,7 +324,7 @@ export default (pi: ExtensionAPI) => {
   pi.registerTool({
     name: "get_market_stats",
     description:
-      "获取A股市场整体统计（涨跌家数、涨停跌停数、平均涨幅、涨跌Top5、总成交额）",
+      "获取A股市场整体统计（涨跌家数、涨停跌停数、平均涨幅、涨跌Top5、总成交额）。问“今天市场情绪/温度如何”用本工具",
     parameters: {
       type: "object",
       properties: {
@@ -344,7 +344,7 @@ export default (pi: ExtensionAPI) => {
   pi.registerTool({
     name: "get_fundamental_context",
     description:
-      "获取A股深度基本面（估值PE/PB/PS + 成长性营收/净利增速 + 盈利能力ROE/毛利率 + 分红历史）",
+      "获取A股深度基本面（估值PE/PB/PS + 成长性营收/净利增速 + 盈利能力ROE/毛利率 + 分红历史）。“公司质地如何/能不能长期持有”用本工具；快速查PE/PB用 get_financials",
     parameters: {
       type: "object",
       properties: {
@@ -366,7 +366,7 @@ export default (pi: ExtensionAPI) => {
   pi.registerTool({
     name: "screen_stocks",
     description:
-      "全市场股票筛选（AlphaSift L1 多因子硬筛）。按PE/PB/市值/换手率/涨跌幅/量比等因子过滤和评分",
+      "全市场股票筛选（AlphaSift L1 多因子硬筛）。按PE/PB/市值/换手率/涨跌幅/量比等因子过滤和评分。“帮我选股/筛选低估值/高换手股票”用本工具",
     parameters: {
       type: "object",
       properties: {
@@ -401,7 +401,7 @@ export default (pi: ExtensionAPI) => {
   pi.registerTool({
     name: "run_backtest",
     description:
-      "策略回测（AlphaEvo）。读取YAML策略定义，在历史数据上模拟交易，输出收益率/回撤/胜率等指标",
+      "策略回测（AlphaEvo）。读取YAML策略定义，在历史数据上模拟交易，输出收益率/回撤/胜率等指标。只想知道单个技术信号的历史胜率用更轻量的 evaluate_signal",
     parameters: {
       type: "object",
       properties: {
@@ -445,7 +445,7 @@ export default (pi: ExtensionAPI) => {
   pi.registerTool({
     name: "evaluate_signal",
     description:
-      "技术信号历史准确率评估 — 回溯历史数据，统计某个技术信号触发后N日的胜率和平均收益。支持9种信号：macd_golden_cross/macd_death_cross/rsi_oversold/rsi_overbought/breakout_20d/breakdown_20d/volume_surge/ma_golden_cross/ma_death_cross",
+      "技术信号历史准确率评估 — 回溯历史数据，统计某个技术信号触发后N日的胜率和平均收益。支持9种信号：macd_golden_cross/macd_death_cross/rsi_oversold/rsi_overbought/breakout_20d/breakdown_20d/volume_surge/ma_golden_cross/ma_death_cross。“金叉/突破策略靠不靠谱”用本工具；要完整模拟交易过程用 run_backtest",
     parameters: {
       type: "object",
       properties: {
@@ -498,7 +498,7 @@ export default (pi: ExtensionAPI) => {
   pi.registerTool({
     name: "resolve_stock_name",
     description:
-      "股票名称智能解析 — 输入中文名（贵州茅台）、拼音（guizhou maotai/gzmt）、部分代码，返回匹配的股票代码。仅支持A股",
+      "股票名称智能解析 — 输入中文名（贵州茅台）、拼音（guizhou maotai/gzmt）、部分代码，返回匹配的股票代码。仅支持A股。用户给出中文名/拼音/部分代码时先调本工具换成代码再调其他工具",
     parameters: {
       type: "object",
       properties: {
@@ -600,7 +600,7 @@ export default (pi: ExtensionAPI) => {
   pi.registerTool({
     name: "calculate_ma",
     description:
-      "独立均线计算器 — 支持任意周期MA（5/10/20/30/60/120/250或自定义）+ 偏离度 + 均线排列 + 金叉死叉检测",
+      "独立均线计算器 — 支持任意周期MA（5/10/20/30/60/120/250或自定义）+ 偏离度 + 均线排列 + 金叉死叉检测。只要均线数值或需要30/120/250等非默认周期时用本工具；综合技术面分析用 get_technical_analysis",
     parameters: {
       type: "object",
       properties: {
@@ -640,7 +640,7 @@ export default (pi: ExtensionAPI) => {
   pi.registerTool({
     name: "get_volume_analysis",
     description:
-      "独立量价分析 — 量价相关性、上涨/下跌日成交量对比、量能趋势、量价模式解读（放量上涨/缩量回调等）",
+      "独立量价分析 — 量价相关性、上涨/下跌日成交量对比、量能趋势、量价模式解读（放量上涨/缩量回调等）。专问量能/量价配合时用本工具；综合技术面判断用 get_technical_analysis，扫当日异动用 detect_anomaly",
     parameters: {
       type: "object",
       properties: {
@@ -678,7 +678,7 @@ export default (pi: ExtensionAPI) => {
   pi.registerTool({
     name: "search_stock_news",
     description:
-      "多引擎股票新闻搜索（支持 Tavily/Brave/SerpAPI）。需配置对应 API Key 环境变量",
+      "多引擎股票新闻搜索（支持 Tavily/Brave/SerpAPI）。需配置对应 API Key 环境变量。get_news 快讯不够或要按主题搜索时用本工具；深度6维情报用 search_comprehensive_intel",
     parameters: {
       type: "object",
       properties: {
@@ -707,7 +707,7 @@ export default (pi: ExtensionAPI) => {
   pi.registerTool({
     name: "search_comprehensive_intel",
     description:
-      "股票综合情报搜索 — 从6个维度（新闻/公告/行情分析/风险/业绩/行业）搜索综合信息",
+      "股票综合情报搜索 — 从6个维度（新闻/公告/行情分析/风险/业绩/行业）搜索综合信息。“深入研究/全面调研这家公司”用本工具；快速看新闻用 get_news",
     parameters: {
       type: "object",
       properties: {
@@ -735,7 +735,7 @@ export default (pi: ExtensionAPI) => {
   pi.registerTool({
     name: "get_social_sentiment",
     description:
-      "获取股票社交媒体情绪数据（Reddit/X/Polymarket）。主要支持美股。需配置 SENTIMENT_API_KEY",
+      "获取股票社交媒体情绪数据。A股：东方财富股吧热度+雪球讨论热度（无需配置）；美股/港股：Reddit/X/Polymarket情绪（需 SENTIMENT_API_KEY）。自动按市场选数据源。“散户在讨论什么/情绪如何”用本工具；看全市场热门讨论用 get_trending_sentiment",
     parameters: {
       type: "object",
       properties: {
@@ -755,7 +755,7 @@ export default (pi: ExtensionAPI) => {
   pi.registerTool({
     name: "get_trending_sentiment",
     description:
-      "获取社交媒体热门趋势（Reddit/X/Polymarket热门股票讨论）。数据缓存10分钟。适用于发现市场热点",
+      "获取社交媒体热门趋势（Reddit/X/Polymarket热门股票讨论）。数据缓存10分钟。“现在市场热点是什么/大家都在买什么”用本工具；查个股情绪用 get_social_sentiment",
     parameters: {
       type: "object",
       properties: {},
@@ -769,7 +769,7 @@ export default (pi: ExtensionAPI) => {
   pi.registerTool({
     name: "extract_article",
     description:
-      "网页文章全文提取 — 输入URL，提取文章标题、正文（最多3000字）、作者、发布日期等。适用于深度阅读搜索结果中的新闻/研报",
+      "网页文章全文提取 — 输入URL，提取文章标题、正文（最多3000字）、作者、发布日期等。配合 get_news/search_stock_news 的搜索结果做深度阅读",
     parameters: {
       type: "object",
       properties: {
@@ -789,7 +789,7 @@ export default (pi: ExtensionAPI) => {
   pi.registerTool({
     name: "screen_risk",
     description:
-      "风险专项筛查 — 7维度风险检测（估值极端/技术预警/解禁到期/内部人减持/业绩预警/监管处罚/行业政策），返回风险评级和一票否决标记",
+      "风险专项筛查 — 7维度风险检测（估值极端/技术预警/解禁到期/内部人减持/业绩预警/监管处罚/行业政策），返回风险评级和一票否决标记。“这股票有什么雷”用本工具；入场决策前排雷必调",
     parameters: {
       type: "object",
       properties: {
@@ -817,7 +817,7 @@ export default (pi: ExtensionAPI) => {
   pi.registerTool({
     name: "detect_market_regime",
     description:
-      "市场状态检测 — 分析大盘指数判断当前市场阶段（上涨趋势/下跌趋势/横盘震荡/高波动/板块热点），并推荐适合的分析策略",
+      "市场状态检测 — 分析大盘指数判断当前市场阶段（上涨趋势/下跌趋势/横盘震荡/高波动/板块热点），并推荐适合的分析策略。“现在大盘能进场吗/该用什么策略”用本工具",
     parameters: {
       type: "object",
       properties: {
@@ -838,7 +838,7 @@ export default (pi: ExtensionAPI) => {
   pi.registerTool({
     name: "get_market_review",
     description:
-      "大盘复盘 — 获取市场日度复盘数据，包含指数、涨跌统计、板块排名、新闻、市场温度与策略建议",
+      "大盘复盘 — 获取市场日度复盘数据，包含指数、涨跌统计、板块排名、新闻、市场温度与策略建议。“复盘一下今天市场/今天大盘怎么样”首选本工具，无需再分别调指数/统计/板块工具",
     parameters: {
       type: "object",
       properties: {
@@ -859,7 +859,7 @@ export default (pi: ExtensionAPI) => {
   pi.registerTool({
     name: "run_watchlist_analysis",
     description:
-      "批量自选股分析 — 对多只股票并行采集行情/技术/资金/风险等数据，返回汇总结果。适用于每日定时分析自选股列表",
+      "批量自选股分析 — 对多只股票并行采集行情/技术/资金/风险等数据，返回汇总结果。“批量分析我的自选股”/每日定时分析用本工具",
     parameters: {
       type: "object",
       properties: {
@@ -888,7 +888,7 @@ export default (pi: ExtensionAPI) => {
   pi.registerTool({
     name: "detect_anomaly",
     description:
-      "异常/事件检测 — 一键扫描股票当前所有异动信号（MACD金叉死叉、RSI超买超卖、20日突破、放量异动、涨跌停、布林突破、KDJ极值、资金异动等），返回结构化异常列表",
+      "异常/事件检测 — 一键扫描股票当前所有异动信号（MACD金叉死叉、RSI超买超卖、20日突破、放量异动、涨跌停、布林突破、KDJ极值、资金异动等），返回结构化异常列表。“今天有什么异动/为什么大涨大跌”首选本工具；综合技术面判断用 get_technical_analysis",
     parameters: {
       type: "object",
       properties: {
@@ -910,7 +910,7 @@ export default (pi: ExtensionAPI) => {
   pi.registerTool({
     name: "diagnose_data_sources",
     description:
-      "数据源诊断 — 检查当前环境可用的数据 provider（akshare/tushare/yfinance/finnhub/longbridge/alphavantage），输出每个市场的可用链路、缺失 env、warnings。用于让 agent 自解释为何拿不到数据",
+      "数据源诊断 — 检查当前环境可用的数据 provider（akshare/tushare/yfinance/finnhub/longbridge/alphavantage），输出每个市场的可用链路、缺失 env、warnings。工具拿不到数据或报错时调用排查",
     parameters: {
       type: "object",
       properties: {
@@ -930,7 +930,7 @@ export default (pi: ExtensionAPI) => {
   pi.registerTool({
     name: "get_market_capabilities",
     description:
-      "市场能力边界 — 返回指定市场支持/不支持的工具列表，避免 agent 对港股调 get_chip_distribution 或对美股调 get_capital_flow 后编造数据",
+      "市场能力边界 — 返回指定市场支持/不支持的工具列表。不确定某市场能否用某工具（如港股的筹码分布、美股的资金流）时先调本工具，避免调用不支持的工具后编造数据",
     parameters: {
       type: "object",
       properties: {
@@ -952,7 +952,7 @@ export default (pi: ExtensionAPI) => {
   pi.registerTool({
     name: "render_stock_report",
     description:
-      "股票分析报告渲染 — 将结构化 JSON（符合 schemas/report_schema.json）通过 j2 模板渲染为 Markdown。style: brief|full。仅渲染，不保存不推送",
+      "股票分析报告渲染 — 将结构化 JSON（符合 schemas/report_schema.json）通过 j2 模板渲染为 Markdown。template: brief|full。全部分析完成后的最后一步调用。仅渲染，不保存不推送",
     parameters: {
       type: "object",
       properties: {
@@ -1039,7 +1039,7 @@ export default (pi: ExtensionAPI) => {
   pi.registerTool({
     name: "analyze_position_context",
     description:
-      "持仓上下文分析 — 输入成本/仓位/止损止盈，结合现价和技术位输出浮盈亏、离止损距离、风险级别、操作建议。无状态、不存账户",
+      "持仓上下文分析 — 输入成本/仓位/止损止盈，结合现价和技术位输出浮盈亏、离止损距离、风险级别、操作建议。“我XX成本买的被套了/要不要止损止盈”用本工具。无状态、不存账户",
     parameters: {
       type: "object",
       properties: {
@@ -1069,7 +1069,7 @@ export default (pi: ExtensionAPI) => {
   pi.registerTool({
     name: "check_alert_rules",
     description:
-      "无状态告警规则检查 — 传入规则数组，返回当前是否触发。规则类型：price_below/price_above/change_pct_above/change_pct_below/volume_ratio_above/anomaly/risk_veto/risk_level_at_least。不做调度不存历史",
+      "无状态告警规则检查 — 传入规则数组，返回当前是否触发。规则类型：price_below/price_above/change_pct_above/change_pct_below/volume_ratio_above/anomaly/risk_veto/risk_level_at_least。“到价/涨跌幅提醒是否触发”用本工具。不做调度不存历史",
     parameters: {
       type: "object",
       properties: {

--- a/skills/stock-analysis/SKILL.md
+++ b/skills/stock-analysis/SKILL.md
@@ -1,12 +1,23 @@
 ---
 name: stock-analysis
-description: 综合股票分析 — 技术面+基本面+资金面+消息面+风险筛查多维研判。当用户要求分析个股时使用。
+description: 综合股票分析 — 技术面+基本面+资金面+消息面+风险筛查多维研判。当用户要求分析个股，或问"XX怎么样/能买吗/现在能入场吗/走势如何/有什么雷/被套怎么办"等泛化问题时使用。
 allowed-tools: Bash(python3:*) Read
 ---
 
 # 综合股票分析
 
 你是一位专业的股票分析师。用户提供股票代码后，你需要进行全面的多维度分析并输出结构化研报。
+
+## 意图路由表
+
+快速问答先判断意图，按下表走最短调用链；完整综合研判走下方执行流程（gather 采集管线），不受此表限制。单工具可答的问题（新闻/资金/风险/基本面/持仓/复盘/选股等）直接按各工具描述中的“何时用”选择，本表不再重复。
+
+| 用户意图 | 调用序列 |
+|---------|---------|
+| “能买吗 / 能入场吗 / 现在能进吗” | `get_technical_analysis` → `get_capital_flow`(summary, 仅A股) → `screen_risk` → `detect_market_regime`。合成规则：screen_risk 有一票否决则不入场（无视评分）；BUY/STRONG_BUY + 主力净流入 + 大盘非下跌 → 可入场；大盘下跌趋势中个股 BUY 降级为轻仓试错或等待；HOLD/WAIT 则给出具体触发条件（如回踩 MA10 不破、放量突破 20 日高点） |
+| “现在怎么样 / 走势如何” | `get_quote` + `get_technical_analysis` |
+| “有什么异动 / 为什么大涨大跌” | `detect_anomaly` + `get_news` |
+| “大盘现在能进场吗” | `detect_market_regime` + `get_market_stats` |
 
 ## 执行流程
 

--- a/skills/stock-analysis/SKILL.md
+++ b/skills/stock-analysis/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: stock-analysis
-description: 综合股票分析 — 技术面+基本面+资金面+消息面+风险筛查多维研判。当用户要求分析个股，或问"XX怎么样/能买吗/现在能入场吗/走势如何/有什么雷/被套怎么办"等泛化问题时使用。
+description: 综合股票分析 — 技术面+基本面+资金面+消息面+风险筛查多维研判。用于个股综合研判类问题：走势判断、买卖时机、风险排雷、持仓处理。
 allowed-tools: Bash(python3:*) Read
 ---
 
@@ -10,14 +10,14 @@ allowed-tools: Bash(python3:*) Read
 
 ## 意图路由表
 
-快速问答先判断意图，按下表走最短调用链；完整综合研判走下方执行流程（gather 采集管线），不受此表限制。单工具可答的问题（新闻/资金/风险/基本面/持仓/复盘/选股等）直接按各工具描述中的“何时用”选择，本表不再重复。
+快速问答先判断意图，按下表走最短调用链；完整综合研判走下方执行流程（gather 采集管线），不受此表限制。单工具可答的问题按各工具描述中的适用场景选择，本表不再重复。
 
-| 用户意图 | 调用序列 |
-|---------|---------|
-| “能买吗 / 能入场吗 / 现在能进吗” | `get_technical_analysis` → `get_capital_flow`(summary, 仅A股) → `screen_risk` → `detect_market_regime`。合成规则：screen_risk 有一票否决则不入场（无视评分）；BUY/STRONG_BUY + 主力净流入 + 大盘非下跌 → 可入场；大盘下跌趋势中个股 BUY 降级为轻仓试错或等待；HOLD/WAIT 则给出具体触发条件（如回踩 MA10 不破、放量突破 20 日高点） |
-| “现在怎么样 / 走势如何” | `get_quote` + `get_technical_analysis` |
-| “有什么异动 / 为什么大涨大跌” | `detect_anomaly` + `get_news` |
-| “大盘现在能进场吗” | `detect_market_regime` + `get_market_stats` |
+| 意图 | 调用序列 |
+|------|---------|
+| 个股买卖时机 | `get_technical_analysis` → `get_capital_flow`(summary, 仅A股) → `screen_risk` → `detect_market_regime`。合成规则：screen_risk 有一票否决则不入场（无视评分）；BUY/STRONG_BUY + 主力净流入 + 大盘非下跌 → 可入场；大盘下跌趋势中个股 BUY 降级为轻仓试错或等待；HOLD/WAIT 则给出具体触发条件（如回踩 MA10 不破、放量突破 20 日高点） |
+| 个股状态速览 | `get_quote` + `get_technical_analysis` |
+| 异动归因 | `detect_anomaly` + `get_news` |
+| 大盘择时 | `detect_market_regime` + `get_market_stats` |
 
 ## 执行流程
 


### PR DESCRIPTION
## 背景

39 个工具平铺注册，但描述只有一句话功能说明，缺少"何时用/何时别用"信息，导致模型在近义工具间（资讯族 6 个、技术面族 5 个）选择质量差，泛化问题（"能买吗""走势如何"）也不会路由到正确的工具链。

## 改动

**纯描述/Markdown 变更，不动工具名、参数、JSON 输出结构和任何执行逻辑。**

- **33 个工具描述四端同步改写**（pi / openclaw / dsh / hermes schemas）：是什么 + 何时用 + 何时别用（指向替代工具）；近义工具族互相交叉引用。例：
  - `get_news` → "轻量快讯。深度情报用 search_comprehensive_intel，主题搜索用 search_stock_news，读全文用 extract_article"
  - `get_technical_analysis` → "「能买吗/现在能入场吗」首选本工具；只要均线用 calculate_ma，扫异动用 detect_anomaly"
- **修复 2 个描述错误**（review 发现）：
  - `render_stock_report`：描述参数名 `style` → `template`（与实际参数和 CLI `--template` 一致）
  - `get_social_sentiment`：改为与实现一致的 market-aware 表述（A股走东财股吧+雪球、无需 key；美股/港股走 Reddit/X/Polymarket）
- **消除既有漂移**：4 个工具描述在 hermes 与 TS 适配器间本不一致，现在 39 × 4 端逐字一致（脚本断言）
- **skills/stock-analysis/SKILL.md**：frontmatter 触发词放宽到口语化问法；新增意图路由表——只保留描述层表达不了的多步调用链（"能买吗" → technical → capital_flow → screen_risk → regime，含合成规则）和工具配对，单工具路由交给描述层，避免双源漂移

## 验证

- `ruff check` + `ruff format --check` ✅
- `npx tsc --noEmit` ✅
- `pytest`：452 passed ✅
- 四端注册测试（pi / openclaw / dsh / hermes）✅
- `build:openclaw` / `build:dsh` bundle 重建并确认新描述进入产物 ✅
- 经 code-review（Standards / Spec 双轴）+ ponytail-review 三轮迭代至无残留发现