### PR TITLE
fix: Bocha 搜索解析修正 + 引擎失败原因透出 (ref #13)

### DIFF
--- a/tests/test_search_intel.py
+++ b/tests/test_search_intel.py
@@ -3,12 +3,15 @@
 import sys
 from unittest.mock import MagicMock, patch
 
-from tools.search_intel import _searxng_search, search_news
+import pytest
+
+from tools.search_intel import _bocha_search, _searxng_search, search_comprehensive, search_news
 
 
-def _mock_requests(payload, ok=True):
+def _mock_requests(payload, ok=True, status_code=200):
     mock_resp = MagicMock()
     mock_resp.ok = ok
+    mock_resp.status_code = status_code
     mock_resp.json.return_value = payload
     mock_req = MagicMock()
     mock_req.get.return_value = mock_resp
@@ -51,11 +54,108 @@ class TestSearxngSearch:
         assert mock_req.get.call_args[0][0] == "http://good:8080/search"
 
     @patch.dict("os.environ", {"SEARXNG_BASE_URLS": "http://127.0.0.1:8080"})
-    def test_exception_returns_empty(self):
+    def test_exception_raises_with_reason(self):
         mock_req = MagicMock()
         mock_req.get.side_effect = Exception("network down")
+        with patch.dict(sys.modules, {"requests": mock_req}), pytest.raises(RuntimeError, match="network down"):
+            _searxng_search("query")
+
+    @patch.dict("os.environ", {"SEARXNG_BASE_URLS": "http://down:8080, http://empty:8080"})
+    def test_reachable_but_empty_is_not_an_error(self):
+        # one instance down, another healthy but zero hits → legit empty, no raise
+        mock_req = MagicMock()
+        empty_resp = MagicMock(ok=True)
+        empty_resp.json.return_value = {"results": []}
+        mock_req.get.side_effect = [Exception("conn refused"), empty_resp]
         with patch.dict(sys.modules, {"requests": mock_req}):
             assert _searxng_search("query") == []
+
+
+class TestBochaSearch:
+    @patch.dict("os.environ", {}, clear=True)
+    def test_no_api_key_returns_empty(self):
+        assert _bocha_search("test query") == []
+
+    @patch.dict("os.environ", {"BOCHA_API_KEY": "k"})
+    def test_parses_bing_style_webpages_value(self):
+        # Real Bocha response: data.webPages.value[] (issue #13)
+        payload = {
+            "code": 200,
+            "data": {
+                "webPages": {
+                    "totalEstimatedMatches": 10000000,
+                    "value": [
+                        {"name": "T1", "url": "http://a.com/1", "snippet": "s1"},
+                        {"name": "T2", "url": "http://a.com/2", "snippet": None},
+                    ],
+                }
+            },
+        }
+        with patch.dict(sys.modules, {"requests": _mock_requests(payload)}):
+            results = _bocha_search("600519 最新消息")
+        assert len(results) == 2
+        assert results[0]["source"] == "bocha"
+        assert results[0]["title"] == "T1"
+        assert results[0]["url"] == "http://a.com/1"
+        assert results[0]["snippet"] == "s1"
+        # None snippet degrades to empty string, not a crash
+        assert results[1]["snippet"] == ""
+
+    @patch.dict("os.environ", {"BOCHA_API_KEY": "k"})
+    def test_http_error_raises_with_status(self):
+        mock_req = _mock_requests({}, ok=False, status_code=403)
+        with patch.dict(sys.modules, {"requests": mock_req}), pytest.raises(RuntimeError, match="403"):
+            _bocha_search("query")
+
+    @patch.dict("os.environ", {"BOCHA_API_KEY": "k"})
+    def test_body_code_error_raises(self):
+        # Bocha can signal failure via HTTP 200 + non-200 envelope code (e.g. quota)
+        payload = {"code": 403, "msg": "no quota"}
+        with (
+            patch.dict(sys.modules, {"requests": _mock_requests(payload)}),
+            pytest.raises(RuntimeError, match="no quota"),
+        ):
+            _bocha_search("query")
+
+
+class TestSearchNewsEngineErrors:
+    @patch.dict("os.environ", {"BOCHA_API_KEY": "k"}, clear=True)
+    def test_engine_failure_recorded_in_engines_errors(self):
+        mock_req = _mock_requests({}, ok=False, status_code=403)
+        with patch.dict(sys.modules, {"requests": mock_req}):
+            result = search_news("some query")
+        assert result["results"] == []
+        assert "bocha" in result["engines_errors"]
+        assert "403" in result["engines_errors"]["bocha"]
+        # unconfigured engines produce no error entries
+        assert "tavily" not in result["engines_errors"]
+
+    @patch.dict("os.environ", {"SERPAPI_KEY": "SECRET123"}, clear=True)
+    def test_error_message_scrubs_api_key(self):
+        # requests connection errors embed the prepared URL — api_key must not leak
+        mock_req = MagicMock()
+        mock_req.get.side_effect = Exception("Max retries exceeded with url: /search?api_key=SECRET123&q=x")
+        with patch.dict(sys.modules, {"requests": mock_req}):
+            result = search_news("some query")
+        assert "serpapi" in result["engines_errors"]
+        assert "SECRET123" not in result["engines_errors"]["serpapi"]
+
+    @patch.dict("os.environ", {"BOCHA_API_KEY": "k"}, clear=True)
+    def test_note_says_engines_failed_not_unconfigured(self):
+        mock_req = _mock_requests({}, ok=False, status_code=403)
+        with patch.dict(sys.modules, {"requests": mock_req}):
+            result = search_news("some query")
+        assert result["results"] == []
+        assert "No search engines configured" not in result["note"]
+        assert "engines_errors" in result["note"]
+
+    @patch.dict("os.environ", {"BOCHA_API_KEY": "k"}, clear=True)
+    def test_comprehensive_surfaces_engines_errors(self):
+        mock_req = _mock_requests({}, ok=False, status_code=403)
+        with patch.dict(sys.modules, {"requests": mock_req}):
+            result = search_comprehensive("600519", "贵州茅台")
+        assert result["engines_errors"]["bocha"]
+        assert "403" in result["engines_errors"]["bocha"]
 
 
 class TestSearchNewsSearxngFallback:

--- a/tools/search_intel.py
+++ b/tools/search_intel.py
@@ -27,123 +27,130 @@ def _cache_set(key: str, data):
 
 # --------------- Web Search ---------------
 
+_SECRET_PARAM_RE = re.compile(r"(?i)((?:api[_-]?key|token|secret|access[_-]?token)=)[^&\s]+")
+
+
+def _scrub_secrets(msg: str) -> str:
+    """Error text may embed request URLs (requests connection errors) — never leak keys to stdout JSON."""
+    return _SECRET_PARAM_RE.sub(r"\1***", msg)
+
 
 def _tavily_search(query: str, max_results: int = 5) -> list[dict]:
     api_key = os.environ.get("TAVILY_API_KEY")
     if not api_key:
         return []
-    try:
-        import requests
+    import requests
 
-        resp = requests.post(
-            "https://api.tavily.com/search",
-            json={
-                "api_key": api_key,
-                "query": query,
-                "max_results": max_results,
-                "search_depth": "basic",
-            },
-            timeout=15,
-        )
-        data = resp.json()
-        return [
-            {
-                "title": r.get("title", ""),
-                "url": r.get("url", ""),
-                "snippet": r.get("content", "")[:200],
-                "source": "tavily",
-            }
-            for r in data.get("results", [])
-        ]
-    except Exception:
-        return []
+    resp = requests.post(
+        "https://api.tavily.com/search",
+        json={
+            "api_key": api_key,
+            "query": query,
+            "max_results": max_results,
+            "search_depth": "basic",
+        },
+        timeout=15,
+    )
+    if not resp.ok:
+        raise RuntimeError(f"tavily HTTP {resp.status_code}")
+    data = resp.json()
+    return [
+        {
+            "title": r.get("title", ""),
+            "url": r.get("url", ""),
+            "snippet": r.get("content", "")[:200],
+            "source": "tavily",
+        }
+        for r in data.get("results", [])
+    ]
 
 
 def _brave_search(query: str, count: int = 5) -> list[dict]:
     api_key = os.environ.get("BRAVE_API_KEY")
     if not api_key:
         return []
-    try:
-        import requests
+    import requests
 
-        resp = requests.get(
-            "https://api.search.brave.com/res/v1/web/search",
-            headers={"X-Subscription-Token": api_key, "Accept": "application/json"},
-            params={"q": query, "count": count},
-            timeout=15,
-        )
-        data = resp.json()
-        return [
-            {
-                "title": r.get("title", ""),
-                "url": r.get("url", ""),
-                "snippet": r.get("description", "")[:200],
-                "source": "brave",
-            }
-            for r in data.get("web", {}).get("results", [])
-        ]
-    except Exception:
-        return []
+    resp = requests.get(
+        "https://api.search.brave.com/res/v1/web/search",
+        headers={"X-Subscription-Token": api_key, "Accept": "application/json"},
+        params={"q": query, "count": count},
+        timeout=15,
+    )
+    if not resp.ok:
+        raise RuntimeError(f"brave HTTP {resp.status_code}")
+    data = resp.json()
+    return [
+        {
+            "title": r.get("title", ""),
+            "url": r.get("url", ""),
+            "snippet": r.get("description", "")[:200],
+            "source": "brave",
+        }
+        for r in data.get("web", {}).get("results", [])
+    ]
 
 
 def _serpapi_search(query: str, num: int = 5) -> list[dict]:
     api_key = os.environ.get("SERPAPI_KEY")
     if not api_key:
         return []
-    try:
-        import requests
+    import requests
 
-        resp = requests.get(
-            "https://serpapi.com/search",
-            params={
-                "api_key": api_key,
-                "q": query,
-                "num": num,
-                "engine": "google",
-            },
-            timeout=15,
-        )
-        data = resp.json()
-        return [
-            {
-                "title": r.get("title", ""),
-                "url": r.get("link", ""),
-                "snippet": r.get("snippet", "")[:200],
-                "source": "serpapi",
-            }
-            for r in data.get("organic_results", [])
-        ]
-    except Exception:
-        return []
+    resp = requests.get(
+        "https://serpapi.com/search",
+        params={
+            "api_key": api_key,
+            "q": query,
+            "num": num,
+            "engine": "google",
+        },
+        timeout=15,
+    )
+    if not resp.ok:
+        raise RuntimeError(f"serpapi HTTP {resp.status_code}")
+    data = resp.json()
+    return [
+        {
+            "title": r.get("title", ""),
+            "url": r.get("link", ""),
+            "snippet": r.get("snippet", "")[:200],
+            "source": "serpapi",
+        }
+        for r in data.get("organic_results", [])
+    ]
 
 
 def _bocha_search(query: str, max_results: int = 5) -> list[dict]:
     api_key = os.environ.get("BOCHA_API_KEY")
     if not api_key:
         return []
-    try:
-        import requests
+    import requests
 
-        resp = requests.post(
-            "https://api.bochaai.com/v1/web-search",
-            headers={"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"},
-            json={"query": query, "count": max_results},
-            timeout=15,
-        )
-        data = resp.json()
-        results = []
-        for item in data.get("web", {}).get("results", []):
-            results.append(
-                {
-                    "title": item.get("name", ""),
-                    "url": item.get("url", ""),
-                    "snippet": item.get("snippet", "")[:200],
-                    "source": "bocha",
-                }
-            )
-        return results
-    except Exception:
-        return []
+    resp = requests.post(
+        "https://api.bochaai.com/v1/web-search",
+        headers={"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"},
+        json={"query": query, "count": max_results},
+        timeout=15,
+    )
+    if not resp.ok:
+        raise RuntimeError(f"bocha HTTP {resp.status_code}")
+    data = resp.json()
+    code = data.get("code")
+    if code is not None and str(code) != "200":
+        # Bocha can signal quota/auth failure via HTTP 200 + non-200 envelope code
+        raise RuntimeError(f"bocha code {code}: {data.get('msg') or data.get('message') or 'unknown'}")
+    # Bocha web-search returns Bing-style data.webPages.value[] (issue #13)
+    items = ((data.get("data") or {}).get("webPages") or {}).get("value") or []
+    return [
+        {
+            "title": item.get("name", ""),
+            "url": item.get("url", ""),
+            "snippet": (item.get("snippet") or "")[:200],
+            "source": "bocha",
+        }
+        for item in items
+    ]
 
 
 def _searxng_search(query: str, max_results: int = 5) -> list[dict]:
@@ -155,10 +162,10 @@ def _searxng_search(query: str, max_results: int = 5) -> list[dict]:
     base_urls = [u.strip().rstrip("/") for u in os.environ.get("SEARXNG_BASE_URLS", "").split(",") if u.strip()]
     if not base_urls:
         return []
-    try:
-        import requests
-    except ImportError:
-        return []
+    import requests
+
+    last_error = None
+    responded = False
     for base in base_urls:
         try:
             resp = requests.get(
@@ -168,7 +175,9 @@ def _searxng_search(query: str, max_results: int = 5) -> list[dict]:
                 timeout=15,
             )
             if not resp.ok:
+                last_error = f"searxng {base} HTTP {resp.status_code}"
                 continue
+            responded = True
             data = resp.json()
             results = [
                 {
@@ -181,8 +190,10 @@ def _searxng_search(query: str, max_results: int = 5) -> list[dict]:
             ]
             if results:
                 return results
-        except Exception:
-            continue
+        except Exception as e:
+            last_error = f"searxng {base}: {e}"
+    if last_error and not responded:
+        raise RuntimeError(last_error)
     return []
 
 
@@ -190,6 +201,7 @@ def search_news(query: str, max_results: int = 10) -> dict:
     results = []
     engines_tried = []
     engines_available = []
+    engines_errors = {}
 
     for name, fn in [
         ("tavily", _tavily_search),
@@ -199,7 +211,11 @@ def search_news(query: str, max_results: int = 10) -> dict:
         ("searxng", _searxng_search),
     ]:
         engines_tried.append(name)
-        items = fn(query, max_results)
+        try:
+            items = fn(query, max_results)
+        except Exception as e:
+            engines_errors[name] = _scrub_secrets(str(e))
+            continue
         if items:
             engines_available.append(name)
             results.extend(items)
@@ -207,14 +223,19 @@ def search_news(query: str, max_results: int = 10) -> dict:
                 break
 
     if not results:
+        if engines_errors:
+            note = "All configured search engines failed; see engines_errors for per-engine reasons."
+        else:
+            note = (
+                "No search engines configured. Set TAVILY_API_KEY, BRAVE_API_KEY, BOCHA_API_KEY, "
+                "SERPAPI_KEY, or SEARXNG_BASE_URLS in environment."
+            )
         return {
             "query": query,
             "results": [],
             "engines_tried": engines_tried,
-            "note": (
-                "No search engines configured. Set TAVILY_API_KEY, BRAVE_API_KEY, BOCHA_API_KEY, "
-                "SERPAPI_KEY, or SEARXNG_BASE_URLS in environment."
-            ),
+            "engines_errors": engines_errors,
+            "note": note,
         }
 
     seen_urls = set()
@@ -228,6 +249,7 @@ def search_news(query: str, max_results: int = 10) -> dict:
         "query": query,
         "results": deduped[:max_results],
         "engines_used": engines_available,
+        "engines_errors": engines_errors,
         "total": len(deduped),
     }
 
@@ -244,11 +266,13 @@ def search_comprehensive(symbol: str, name: str = None) -> dict:
     }
 
     results = {}
+    engines_errors = {}
     for dim, query in dimensions.items():
         data = search_news(query, max_results=3)
         results[dim] = data.get("results", [])
+        engines_errors.update(data.get("engines_errors") or {})
 
-    return {"symbol": symbol, "name": label, "dimensions": results}
+    return {"symbol": symbol, "name": label, "dimensions": results, "engines_errors": engines_errors}
 
 
 # --------------- A-share Sentiment Sources ---------------


### PR DESCRIPTION
## 关联 Issue

Ref #13 （仅引用，不自动关闭）

## 问题

`_bocha_search` 按 `data.web.results` 解析响应，但 Bocha web-search API 实际返回 Bing 风格结构 `data.webPages.value[]`，导致 Bocha 引擎即使 HTTP 200 也永远解析出 0 条结果，最终统一误报 `No search engines configured`。

## 修复

- **Bocha 解析**:改按 `data.data.webPages.value[]` 取结果（title←name, snippet 截断 200 字符）,并校验信封级 `code`——HTTP 200 但 `code != 200`（如 403 配额不足）不再静默吞掉
- **engines_errors**:各引擎失败（HTTP 非 2xx / 网络错误 / 解析失败）抛出带原因的异常,`search_news` 汇总为 `engines_errors` 字段（纯增量 key，四端适配器无需改动）;`search_comprehensive` 同步聚合透出
- **脱敏**:错误文本记录前经 `_scrub_secrets` 处理，防止 serpapi 这类把 `api_key` 放在 URL query 的服务，经 requests 连接异常把 key 泄进 stdout JSON
- **note 修正**:仅在确实无引擎配置时才提示 "No search engines configured"；配置但全部失败时改为 "All configured search engines failed; see engines_errors"
- **SearXNG**:仅当所有实例都无响应时才报错；一个实例挂、另一个健康但零命中 → 正常返回空

## 测试

- `tests/test_search_intel.py` 15 个测试全绿（新增：Bing 风格解析、`None` snippet、HTTP 403、信封 code 错误、api_key 脱敏、note 文案、comprehensive 透出、SearXNG 边界）
- 全量离线测试 461 passed;`ruff check` / `ruff format --check` 干净
- 改动仅限 `tools/` Python 核心，工具名/参数无变化，输出仅增量加 key,pi/openclaw/dsh/hermes 四端适配器无需同步修改